### PR TITLE
feat(user): implement registerNotificationToken usecase

### DIFF
--- a/domain/src/features/user/domain-events.ts
+++ b/domain/src/features/user/domain-events.ts
@@ -8,3 +8,11 @@ export const NotGottenUserDomainEvent = DomainEventKind(
 export const GottenUserDomainEvent = DomainEventKind<UserEntity>(
   "GottenUserDomainEvent",
 );
+
+export const NotificationTokenAssignedDomainEvent = DomainEventKind<UserEntity>(
+  "NotificationTokenAssignedDomainEvent",
+);
+
+export const NotificationTokenAssignmentFailedDomainEvent = DomainEventKind(
+  "NotificationTokenAssignmentFailedDomainEvent",
+);

--- a/domain/src/features/user/index.ts
+++ b/domain/src/features/user/index.ts
@@ -7,3 +7,5 @@ export { GetUserByIdParam } from "./usecases/get-user-by-id/get-user-by-id.param
 export { GetUserByIdUsecase } from "./usecases/get-user-by-id/get-user-by-id.usecase";
 export { CreateUserParam } from "./usecases/create-user/create-user.param";
 export { CreateUserUsecase } from "./usecases/create-user/create-user.usecase";
+export { RegisterNotificationTokenParam } from "./usecases/register-notification-token/register-notification-token.param";
+export { RegisterNotificationTokenUsecase } from "./usecases/register-notification-token/register-notification-token.usecase";

--- a/domain/src/features/user/usecases/register-notification-token/register-notification-token.param.ts
+++ b/domain/src/features/user/usecases/register-notification-token/register-notification-token.param.ts
@@ -1,0 +1,7 @@
+import { Id } from "../../../../core/entity";
+
+export interface RegisterNotificationTokenParam {
+  userId: Id;
+  token: string;
+}
+

--- a/domain/src/features/user/usecases/register-notification-token/register-notification-token.usecase.ts
+++ b/domain/src/features/user/usecases/register-notification-token/register-notification-token.usecase.ts
@@ -1,0 +1,5 @@
+import { Usecase } from "../../../../core/usecase";
+import { RegisterNotificationTokenParam } from "./register-notification-token.param";
+
+export abstract class RegisterNotificationTokenUsecase extends Usecase<RegisterNotificationTokenParam> {}
+

--- a/domain/src/features/user/user.entity.ts
+++ b/domain/src/features/user/user.entity.ts
@@ -3,15 +3,18 @@ import { Entity, Id } from "../../core/entity";
 export interface UserAttributes {
   id: Id;
   name: string;
+  notificationToken: string;
 }
 
 export class UserEntity extends Entity {
   name: string;
+  notificationToken: string;
 
   private constructor(attributes: UserAttributes) {
-    const { id, name } = attributes;
+    const { id, name, notificationToken } = attributes;
     super(id);
     this.name = name;
+    this.notificationToken = notificationToken;
   }
 
   static build(params: UserAttributes): UserEntity {

--- a/server/src/features/user/usecases/register-notification-token.usecase-impl.ts
+++ b/server/src/features/user/usecases/register-notification-token.usecase-impl.ts
@@ -1,0 +1,35 @@
+import { DomainEvent } from "@skorify/domain/core";
+import {
+  RegisterNotificationTokenParam,
+  RegisterNotificationTokenUsecase,
+  UserContract,
+  NotificationTokenAssignedDomainEvent,
+  NotGottenUserDomainEvent,
+  NotificationTokenAssignmentFailedDomainEvent,
+} from "@skorify/domain/user";
+
+export class RegisterNotificationTokenUsecaseImpl extends RegisterNotificationTokenUsecase {
+  constructor(private userContract: UserContract) {
+    super();
+  }
+
+  async call(param: RegisterNotificationTokenParam): Promise<DomainEvent> {
+    const { userId, token } = param;
+
+    const userInDB = await this.userContract.getById(userId);
+
+    if (!userInDB) {
+      return NotGottenUserDomainEvent();
+    }
+
+    userInDB.notificationToken = token;
+    const savedUser = await this.userContract.save(userInDB);
+
+    if (!savedUser) {
+      return NotificationTokenAssignmentFailedDomainEvent();
+    }
+
+    return NotificationTokenAssignedDomainEvent(savedUser);
+  }
+}
+

--- a/shared/package.json
+++ b/shared/package.json
@@ -2,8 +2,8 @@
   "name": "@skorify/shared",
   "version": "1.0.0",
   "description": "",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "npx tsc -p tsconfig.json && pnpm run copy-package && pnpm run copy-all",
     "copy-package": "copyfiles  package.json dist/",


### PR DESCRIPTION
## Summary

- Implement `registerNotificationToken` usecase for the User feature.
- Expose HTTP endpoint: `PUT /user/register-notification-token`.

## Changes

### Domain Layer
- Add optional `notificationToken?: string` to `UserEntity`.
- Create abstract `RegisterNotificationTokenUsecase` and param interface.
- Add `NotificationTokenAssignedDomainEvent` and `NotificationTokenAssignmentFailedDomainEvent` to user events.

### Server Layer
- Implement `RegisterNotificationTokenUsecaseImpl` which retrieves the user, updates the token, and persists the change.
- Endpoint auto-registered via Iraca under `/user/register-notification-token`.

### Shared Layer
- Fixed `package.json` invalid `main` and `types` fields.