### PR TITLE
fix: alinea BasePathMapping a develop (DependsOn: ApiGatewayApi)

### DIFF
--- a/builders/src/impl/module-lambda-aws/templates/global.template.yaml
+++ b/builders/src/impl/module-lambda-aws/templates/global.template.yaml
@@ -250,7 +250,7 @@ Resources:
 
   ApiGatewayBasePathMapping:
     Type: AWS::ApiGateway::BasePathMapping
-    DependsOn: ApiGatewayApiProdStage
+    DependsOn: ApiGatewayApi
     Properties:
       DomainName: !Ref ApiGatewayCustomDomain
       RestApiId: !Ref ApiGatewayApi


### PR DESCRIPTION
El DependsOn quedó en `ApiGatewayApiProdStage` (PR #122), logical ID que SAM no genera (el stage implícito es `ApiGatewayApiprodStage`, minúscula) → el changeset de prod falla con *Unresolved resource dependencies*.

Se vuelve a `ApiGatewayApi`, dejando el template idéntico a develop.