### PR TITLE
chore: update dependencies and improve match calculation logic

### DIFF
--- a/builders/src/impl/module-lambda-aws/templates/package.template.json
+++ b/builders/src/impl/module-lambda-aws/templates/package.template.json
@@ -11,7 +11,7 @@
     "@scifamek-open-source/iraca": "9.2.0",
     "@skorify/domain": "github:aws-ug-manizales/Skorify_Domain#main",
     "@skorify/shared": "github:aws-ug-manizales/Skorify_Shared#main",
-    "@skorify/data": "github:aws-ug-manizales/Skorify_Data#v1.4.4",
+    "@skorify/data": "github:aws-ug-manizales/Skorify_Data#v1.4.5",
     "@aws-sdk/client-lambda": "^3.600.0",
     "@aws-sdk/client-ssm": "3.1050.0",
     "@aws-sdk/client-secrets-manager": "3.1050.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,8 +371,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+  semver@7.8.2:
+    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -552,7 +552,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.60.1
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.2
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -774,7 +774,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  semver@7.8.1: {}
+  semver@7.8.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@scifamek-open-source/iraca": "9.2.0",
     "@scifamek-open-source/logger": "1.1.2",
-    "@skorify/data": "github:aws-ug-manizales/Skorify_Data#v1.4.1",
+    "@skorify/data": "github:aws-ug-manizales/Skorify_Data#v1.4.5",
     "@skorify/domain": "github:aws-ug-manizales/Skorify_Domain#main",
     "@skorify/shared": "github:aws-ug-manizales/Skorify_Shared#main"
   },

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       '@skorify/data':
-        specifier: github:aws-ug-manizales/Skorify_Data#v1.4.1
-        version: skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3))
+        specifier: github:aws-ug-manizales/Skorify_Data#v1.4.5
+        version: skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/a7794a3c6b26992cb9d3fa85d8cd84b723cfc963(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3))
       '@skorify/domain':
         specifier: github:aws-ug-manizales/Skorify_Domain#main
-        version: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8
+        version: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f
       '@skorify/shared':
         specifier: github:aws-ug-manizales/Skorify_Shared#main
         version: https://codeload.github.com/aws-ug-manizales/Skorify_Shared/tar.gz/18c345573303ff286ddd9e0aa3add38c4e291669
@@ -493,8 +493,8 @@ packages:
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
-  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8':
-    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8}
+  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f':
+    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f}
     version: 1.2.0
 
   '@skorify/shared@https://codeload.github.com/aws-ug-manizales/Skorify_Shared/tar.gz/18c345573303ff286ddd9e0aa3add38c4e291669':
@@ -1782,8 +1782,8 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
-  skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178:
-    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178}
+  skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/a7794a3c6b26992cb9d3fa85d8cd84b723cfc963:
+    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/a7794a3c6b26992cb9d3fa85d8cd84b723cfc963}
     version: 1.0.0-beta
 
   slash@3.0.0:
@@ -2873,7 +2873,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8': {}
+  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f': {}
 
   '@skorify/shared@https://codeload.github.com/aws-ug-manizales/Skorify_Shared/tar.gz/18c345573303ff286ddd9e0aa3add38c4e291669':
     dependencies:
@@ -2882,7 +2882,7 @@ snapshots:
       '@aws-sdk/client-s3': 3.1063.0
       '@aws-sdk/client-sns': 3.1063.0
       '@aws-sdk/s3-request-presigner': 3.1063.0
-      '@skorify/domain': https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8
+      '@skorify/domain': https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f
 
   '@smithy/core@3.24.6':
     dependencies:
@@ -4261,9 +4261,9 @@ snapshots:
     dependencies:
       semver: 7.8.2
 
-  skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3)):
+  skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/a7794a3c6b26992cb9d3fa85d8cd84b723cfc963(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3)):
     dependencies:
-      '@skorify/domain': https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8
+      '@skorify/domain': https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f
       class-transformer: 0.5.1
       class-validator: 0.15.1
       knex: 3.2.10(pg@8.21.0)

--- a/server/src/features/match/usecases/calculate-match-score.usecase-impl.ts
+++ b/server/src/features/match/usecases/calculate-match-score.usecase-impl.ts
@@ -45,20 +45,17 @@ export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
       return MatchDoesNotExistDomainEvent();
     }
 
-    if(match.status == MatchStatus.Calculated) {
-      return MatchAlreadyCalculatedDomainEvent(match);
-
-    }
     if(match.status !== MatchStatus.Finished) {
       return MatchHasNotFinishedDomainEvent(match);
-
     }
 
     const predictionsDE = await this.getPredictionsByMatchAndTournamentInstanceUsecase.call({
       matchId,
       tournamentInstanceId,
     });
-    const predictions: PredictionEntity[] = predictionsDE.payload as PredictionEntity[];
+
+    let predictions: PredictionEntity[] = predictionsDE.payload as PredictionEntity[];
+    predictions = predictions.filter((prediction) => !prediction.isCalculated);
 
     if (predictions && predictions.length > 0) {
       await this.calculateScores(match, predictions);
@@ -66,7 +63,7 @@ export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
 
     await this.resetStreakForMissingPredictions(matchId, tournamentInstanceId);
 
-    match.status = MatchStatus.Calculated;
+    match.status = MatchStatus.Finished;
     await this.matchContract.modify(match);
 
     return CalculatedMatchDomainEvent(match);
@@ -94,6 +91,7 @@ export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
       awayScore: prediction.awayScore,
       earnedPoints: prediction.earnedPoints,
       hasExactResult: prediction.hasExactResult,
+      isCalculated: true
     });
 
     const clonedPrediction = clonedPredictionDE.payload as PredictionEntity;

--- a/server/src/features/prediction/usecases/make-prediction.usecase-impl.ts
+++ b/server/src/features/prediction/usecases/make-prediction.usecase-impl.ts
@@ -102,6 +102,7 @@ export class MakePredictionUsecaseImpl extends MakePredictionUsecase {
       homeScore,
       earnedPoints: 0,
       hasExactResult: false,
+      isCalculated: false,
       userEnrollmentId: userEnrollment.userEnrollmentId,
       createdAt: new Date(),
     });


### PR DESCRIPTION
- Bump `@skorify/data` to v1.4.5 and update related dependency versions.
- Fix match score calculation logic to filter out already calculated predictions.
- Adjust match status handling to reflect correct progression.
- Upgrade `semver` dependency to v7.8.2 for compatibility improvements.