### PR TITLE
Logging estructurado y pruebas del backend en el CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,8 @@ jobs:
   typecheck:
     uses: aws-ug-manizales/Skorify_DevOps/.github/workflows/shared--build-backend.yml@feature/ci-pr-validation-workflows
 
-  # TODO: reactivar cuando se arregle el setup de jest (falta @types/jest en los
-  # types y ts-jest fuerza commonjs, que no resuelve los exports subpath de
-  # @skorify/domain). El reusable shared--unit-tests-backend.yml ya está listo.
-  # unit-tests:
-  #   uses: aws-ug-manizales/Skorify_DevOps/.github/workflows/shared--unit-tests-backend.yml@feature/ci-pr-validation-workflows
+  unit-tests:
+    uses: aws-ug-manizales/Skorify_DevOps/.github/workflows/shared--unit-tests-backend.yml@feature/ci-pr-validation-workflows
 
   sam-validate:
     runs-on: ubuntu-latest

--- a/builders/package.json
+++ b/builders/package.json
@@ -10,10 +10,13 @@
     "mla": "pnpm ts-node src/index.ts module-lambda-aws",
     "build": "tsc -p tsconfig.json"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@aws-lambda-powertools/logger": "^2.33.1"
+  },
   "devDependencies": {
     "@scifamek-open-source/iraca": "9.2.0",
     "@skorify/domain": "github:aws-ug-manizales/Skorify_Domain#main",
+    "@types/aws-lambda": "^8.10.161",
     "@types/node": "22.5.0",
     "ts-node": "10.9.2",
     "typescript": "5.8.3"

--- a/builders/pnpm-lock.yaml
+++ b/builders/pnpm-lock.yaml
@@ -7,13 +7,20 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@aws-lambda-powertools/logger':
+        specifier: ^2.33.1
+        version: 2.33.1
     devDependencies:
       '@scifamek-open-source/iraca':
         specifier: 9.2.0
         version: 9.2.0
       '@skorify/domain':
         specifier: github:aws-ug-manizales/Skorify_Domain#main
-        version: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/979063aa542f6f2e07366a9de72a71f5a1c72dd1
+        version: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f
+      '@types/aws-lambda':
+        specifier: ^8.10.161
+        version: 8.10.161
       '@types/node':
         specifier: 22.5.0
         version: 22.5.0
@@ -25,6 +32,24 @@ importers:
         version: 5.8.3
 
 packages:
+
+  '@aws-lambda-powertools/commons@2.33.1':
+    resolution: {integrity: sha512-edzvz+zqBl8p9J2Cgo1rFmhd+3ANqr0PQDqowElS3CJ10ioHN2wUYiANGxfalcgbB8ulZxGkRbK3wvEEziV/5w==}
+
+  '@aws-lambda-powertools/logger@2.33.1':
+    resolution: {integrity: sha512-DDnKcv2zghslh2AtrVsa4wHcAuI5M7+JlX65CgdXLk2th0Nr0octJQq0f4Bnp+DzuwFynmH4GJqsBe33rZapAw==}
+    peerDependencies:
+      '@aws-lambda-powertools/jmespath': 2.33.1
+      '@middy/core': 4.x || 5.x || 6.x || 7.x
+    peerDependenciesMeta:
+      '@aws-lambda-powertools/jmespath':
+        optional: true
+      '@middy/core':
+        optional: true
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -43,8 +68,8 @@ packages:
   '@scifamek-open-source/iraca@9.2.0':
     resolution: {integrity: sha512-YUyAT5+lfq6+/ARc1TlewTQsm2fR3iZZGNxjaodciX7nDpFJVyu85qtGQvfEaxKJoJT9+KxtMw+Vl4qmz6JHBA==}
 
-  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/979063aa542f6f2e07366a9de72a71f5a1c72dd1':
-    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/979063aa542f6f2e07366a9de72a71f5a1c72dd1}
+  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f':
+    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f}
     version: 1.2.0
 
   '@tsconfig/node10@1.0.12':
@@ -58,6 +83,9 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/aws-lambda@8.10.161':
+    resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
 
   '@types/node@22.5.0':
     resolution: {integrity: sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==}
@@ -115,6 +143,17 @@ packages:
 
 snapshots:
 
+  '@aws-lambda-powertools/commons@2.33.1':
+    dependencies:
+      '@aws/lambda-invoke-store': 0.2.4
+
+  '@aws-lambda-powertools/logger@2.33.1':
+    dependencies:
+      '@aws-lambda-powertools/commons': 2.33.1
+      '@aws/lambda-invoke-store': 0.2.4
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -130,7 +169,7 @@ snapshots:
 
   '@scifamek-open-source/iraca@9.2.0': {}
 
-  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/979063aa542f6f2e07366a9de72a71f5a1c72dd1': {}
+  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f': {}
 
   '@tsconfig/node10@1.0.12': {}
 
@@ -139,6 +178,8 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@types/aws-lambda@8.10.161': {}
 
   '@types/node@22.5.0':
     dependencies:

--- a/builders/src/general/builder.ts
+++ b/builders/src/general/builder.ts
@@ -123,7 +123,7 @@ export abstract class Builder {
     usecases: UsecasesInfo,
     myClass: string,
     impl: string,
-    subPath?: string
+    subPath: string = ""
   ) {
     let toAdd = "";
 

--- a/builders/src/general/logger.ts
+++ b/builders/src/general/logger.ts
@@ -1,0 +1,17 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+
+export const logger = new Logger({
+  serviceName: process.env.POWERTOOLS_SERVICE_NAME || 'skorify-builders',
+});
+
+export const serializeError = (error: unknown): unknown => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return error;
+};

--- a/builders/src/impl/module-lambda-aws/extra-resources/post-confirmation/index.ts
+++ b/builders/src/impl/module-lambda-aws/extra-resources/post-confirmation/index.ts
@@ -1,7 +1,23 @@
-import { PostConfirmationTriggerEvent } from 'aws-lambda';
+import { Logger } from '@aws-lambda-powertools/logger';
+import type { Context, PostConfirmationTriggerEvent } from 'aws-lambda';
 import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import { Client } from 'pg';
+
+const logger = new Logger({
+  serviceName: process.env.POWERTOOLS_SERVICE_NAME || 'skorify-post-confirmation',
+});
 const secretsClient = new SecretsManagerClient({});
+const serializeError = (error: unknown): unknown => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return error;
+};
 
 interface DbCredentials {
   host: string;
@@ -25,36 +41,61 @@ async function getDbCredentials(): Promise<DbCredentials> {
 
 export const handler = async (
   event: PostConfirmationTriggerEvent,
+  context: Context,
 ): Promise<PostConfirmationTriggerEvent> => {
+  logger.addContext(context);
+  const startedAt = Date.now();
   // Solo actuar en confirmación de registro
   if (event.triggerSource !== 'PostConfirmation_ConfirmSignUp') {
+    logger.debug('Post-confirmation skipped', { triggerSource: event.triggerSource });
     return event;
   }
 
   const { email, name, picture, sub } = event.request.userAttributes;
-  console.log({ email, name, picture, sub });
+  logger.debug('Processing confirmed user', { triggerSource: event.triggerSource });
 
-  const creds = await getDbCredentials();
-  const client = new Client({
-    host: creds.host,
-    port: creds.port,
-    database: creds.dbname,
-    user: creds.username,
-    password: creds.password,
-    ssl: { rejectUnauthorized: false },
-  });
-
+  let client: Client | undefined;
   try {
+    const creds = await getDbCredentials();
+    client = new Client({
+      host: creds.host,
+      port: creds.port,
+      database: creds.dbname,
+      user: creds.username,
+      password: creds.password,
+      ssl: { rejectUnauthorized: false },
+    });
+
     await client.connect();
 
-    await client.query(
+    const result = await client.query(
       `INSERT INTO public.users (name, email, sub, image, role, is_active, created_at, updated_at)
        VALUES ($1, $2, $3, $4, 'general', true, NOW(), NOW())
        ON CONFLICT (email) DO NOTHING`,
       [name || email.split('@')[0], email, sub, picture || null],
     );
+    logger.info('Post-confirmation completed', {
+      triggerSource: event.triggerSource,
+      userCreated: result.rowCount === 1,
+      durationMs: Date.now() - startedAt,
+    });
+  } catch (error) {
+    logger.error('Post-confirmation failed', {
+      triggerSource: event.triggerSource,
+      durationMs: Date.now() - startedAt,
+      error: serializeError(error),
+    });
+    throw error;
   } finally {
-    await client.end();
+    if (client) {
+      try {
+        await client.end();
+      } catch (error) {
+        logger.warn('Failed to close post-confirmation database connection', {
+          error: serializeError(error),
+        });
+      }
+    }
   }
 
   return event;

--- a/builders/src/impl/module-lambda-aws/extra-resources/post-confirmation/package.json
+++ b/builders/src/impl/module-lambda-aws/extra-resources/post-confirmation/package.json
@@ -6,6 +6,7 @@
     "build": "npx esbuild index.ts  --bundle --keep-names --platform=node --target=node22 --outfile=../../dist/post-confirmation/index.js"
   },
   "dependencies": {
+    "@aws-lambda-powertools/logger": "^2.33.1",
     "pg": "^8.13.1",
     "aws-lambda": "1.0.7",
     "@aws-sdk/client-secrets-manager": "3.1058.0"

--- a/builders/src/impl/module-lambda-aws/extra-resources/pre-signup/index.ts
+++ b/builders/src/impl/module-lambda-aws/extra-resources/pre-signup/index.ts
@@ -1,4 +1,5 @@
-import { PreSignUpTriggerEvent } from 'aws-lambda';
+import { Logger } from '@aws-lambda-powertools/logger';
+import type { Context, PreSignUpTriggerEvent } from 'aws-lambda';
 import {
   CognitoIdentityProviderClient,
   ListUsersCommand,
@@ -6,85 +7,134 @@ import {
 } from '@aws-sdk/client-cognito-identity-provider';
 
 const cognitoClient = new CognitoIdentityProviderClient({});
+const logger = new Logger({
+  serviceName: process.env.POWERTOOLS_SERVICE_NAME || 'skorify-pre-signup',
+});
 
-export const handler = async (event: PreSignUpTriggerEvent): Promise<PreSignUpTriggerEvent> => {
-  const email = event.request.userAttributes.email;
-  const userPoolId = event.userPoolId;
+const federatedAccountExistsMessage =
+  'Ya existe una cuenta con este correo electrónico. Por favor inicia sesión con Google.';
 
-  // ─────────────────────────────────────────────
-  // CASO 1: Usuario entra con Google y ya existe con email/password
-  // ─────────────────────────────────────────────
-  if (event.triggerSource === 'PreSignUp_ExternalProvider') {
-    const listResponse = await cognitoClient.send(
-      new ListUsersCommand({
-        UserPoolId: userPoolId,
-        Filter: `email = "${email}"`,
-      })
-    );
+const serializeError = (error: unknown): unknown => {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack };
+  }
 
-    const existingUsers = listResponse.Users || [];
+  return error;
+};
 
-    const nativeUser = existingUsers.find(
-      (u) => u.UserStatus !== 'EXTERNAL_PROVIDER'
-    );
+export const handler = async (
+  event: PreSignUpTriggerEvent,
+  context: Context,
+): Promise<PreSignUpTriggerEvent> => {
+  logger.addContext(context);
+  const startedAt = Date.now();
 
-    if (nativeUser) {
-      const [providerName, providerUserId] = event.userName.split('_');
+  try {
+    const email = event.request.userAttributes.email;
+    const userPoolId = event.userPoolId;
 
-      await cognitoClient.send(
-        new AdminLinkProviderForUserCommand({
+    // ─────────────────────────────────────────────
+    // CASO 1: Usuario entra con Google y ya existe con email/password
+    // ─────────────────────────────────────────────
+    if (event.triggerSource === 'PreSignUp_ExternalProvider') {
+      const listResponse = await cognitoClient.send(
+        new ListUsersCommand({
           UserPoolId: userPoolId,
-          DestinationUser: {
-            ProviderName: 'Cognito',
-            ProviderAttributeValue: nativeUser.Username,
-          },
-          SourceUser: {
-            ProviderName: providerName,
-            ProviderAttributeName: 'Cognito_Subject',
-            ProviderAttributeValue: providerUserId,
-          },
+          Filter: `email = "${email}"`,
         })
       );
+
+      const existingUsers = listResponse.Users || [];
+
+      const nativeUser = existingUsers.find(
+        (u) => u.UserStatus !== 'EXTERNAL_PROVIDER'
+      );
+
+      if (nativeUser) {
+        const [providerName, providerUserId] = event.userName.split('_');
+
+        await cognitoClient.send(
+          new AdminLinkProviderForUserCommand({
+            UserPoolId: userPoolId,
+            DestinationUser: {
+              ProviderName: 'Cognito',
+              ProviderAttributeValue: nativeUser.Username,
+            },
+            SourceUser: {
+              ProviderName: providerName,
+              ProviderAttributeName: 'Cognito_Subject',
+              ProviderAttributeValue: providerUserId,
+            },
+          })
+        );
+      }
+
+      event.response.autoConfirmUser = true;
+      event.response.autoVerifyEmail = true;
+
+      logger.info('Pre-signup completed', {
+        triggerSource: event.triggerSource,
+        action: nativeUser ? 'linked_existing_native_user' : 'auto_confirmed_external_user',
+        durationMs: Date.now() - startedAt,
+      });
+
+      return event;
     }
 
-    event.response.autoConfirmUser = true;
-    event.response.autoVerifyEmail = true;
+    // ─────────────────────────────────────────────
+    // CASO 2: Usuario intenta registrarse con email/password
+    //         y ya existe con Google (proveedor externo)
+    // ─────────────────────────────────────────────
+    if (event.triggerSource === 'PreSignUp_SignUp') {
+      const listResponse = await cognitoClient.send(
+        new ListUsersCommand({
+          UserPoolId: userPoolId,
+          Filter: `email = "${email}"`,
+        })
+      );
+
+      const existingUsers = listResponse.Users || [];
+
+      const federatedUser = existingUsers.find(
+        (u) =>
+          u.UserStatus === 'EXTERNAL_PROVIDER' ||
+          u.Username?.startsWith('google_') ||
+          u.Username?.startsWith('Google_')
+      );
+
+      if (federatedUser) {
+        // Bloquear el registro: ya existe una cuenta con ese email via Google
+        throw new Error(federatedAccountExistsMessage);
+      }
+
+      // Auto-confirmar usuario y verificar email (sin código por correo)
+      event.response.autoConfirmUser = true;
+      event.response.autoVerifyEmail = true;
+      logger.info('Pre-signup completed', {
+        triggerSource: event.triggerSource,
+        action: 'auto_confirmed_native_user',
+        durationMs: Date.now() - startedAt,
+      });
+
+    }
 
     return event;
-  }
+  } catch (error) {
+    const metadata = {
+      triggerSource: event.triggerSource,
+      durationMs: Date.now() - startedAt,
+      error: serializeError(error),
+    };
 
-  // ─────────────────────────────────────────────
-  // CASO 2: Usuario intenta registrarse con email/password
-  //         y ya existe con Google (proveedor externo)
-  // ─────────────────────────────────────────────
-  if (event.triggerSource === 'PreSignUp_SignUp') {
-    const listResponse = await cognitoClient.send(
-      new ListUsersCommand({
-        UserPoolId: userPoolId,
-        Filter: `email = "${email}"`,
-      })
-    );
-
-    const existingUsers = listResponse.Users || [];
-
-    const federatedUser = existingUsers.find(
-      (u) =>
-        u.UserStatus === 'EXTERNAL_PROVIDER' ||
-        u.Username?.startsWith('google_') ||
-        u.Username?.startsWith('Google_')
-    );
-
-    if (federatedUser) {
-      // Bloquear el registro: ya existe una cuenta con ese email via Google
-      throw new Error(
-        'Ya existe una cuenta con este correo electrónico. Por favor inicia sesión con Google.'
-      );
+    if (error instanceof Error && error.message === federatedAccountExistsMessage) {
+      logger.warn('Pre-signup blocked', {
+        ...metadata,
+        reason: 'federated_account_exists',
+      });
+    } else {
+      logger.error('Pre-signup failed', metadata);
     }
 
-    // Auto-confirmar usuario y verificar email (sin código por correo)
-    event.response.autoConfirmUser = true;
-    event.response.autoVerifyEmail = true;
+    throw error;
   }
-
-  return event;
 };

--- a/builders/src/impl/module-lambda-aws/extra-resources/pre-signup/package.json
+++ b/builders/src/impl/module-lambda-aws/extra-resources/pre-signup/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@aws-lambda-powertools/logger": "^2.33.1",
     "aws-lambda": "1.0.7",
     "@aws-sdk/client-cognito-identity-provider": "3.1058.0"
   },

--- a/builders/src/impl/module-lambda-aws/index.ts
+++ b/builders/src/impl/module-lambda-aws/index.ts
@@ -5,6 +5,7 @@ import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { Builder, BuilderConfiguration } from '../../general/builder';
 import { existsFile, toToken, UsecaseInfo, UsecasesInfo } from '../../general/helpers';
+import { logger } from '../../general/logger';
 import { Class } from '../../general/models';
 
 type Templates = {
@@ -74,7 +75,13 @@ export class ModuleLambdaAWSBuilder extends Builder {
       acc[curr.module].usecases.push(curr);
       return acc;
     }, {});
-    console.log(modulesConfig);
+    logger.debug('Module Lambda configuration created', {
+      moduleCount: Object.keys(modulesConfig).length,
+      modules: Object.entries(modulesConfig).map(([module, moduleConfig]: [string, any]) => ({
+        module,
+        usecaseCount: moduleConfig.usecases.length,
+      })),
+    });
 
     for (const module in modulesConfig) {
       let samTemplate = samYMLTemplate;
@@ -149,10 +156,20 @@ export class ModuleLambdaAWSBuilder extends Builder {
 
       samTemplates.push(samTemplate);
       await new Promise<void>((resolve, reject) => {
-        console.log(`cd ${moduleFolder} && pnpm i && pnpm run build`);
+        logger.info('Building generated Lambda module', { module, moduleFolder });
         exec(`cd ${moduleFolder} && pnpm i && pnpm run build`, (error, stdout, stderr) => {
-          if (stdout) console.log(`[${module}] stdout:`, stdout);
-          if (stderr) console.error(`[${module}] stderr:`, stderr);
+          if (stdout) {
+            logger.debug('Generated Lambda module build output', {
+              module,
+              output: stdout.trim(),
+            });
+          }
+          if (stderr) {
+            logger.warn('Generated Lambda module build stderr', {
+              module,
+              output: stderr.trim(),
+            });
+          }
           if (error) {
             reject(new Error(`Build failed for module "${module}": ${error.message}`));
           } else {
@@ -289,8 +306,18 @@ ${Object.entries(envConfigs)
       const buildPath = join(this.generatedFolder, folder);
       await new Promise<void>((resolve, reject) => {
         exec(`cd ${buildPath} && pnpm i && pnpm run build`, (error, stdout, stderr) => {
-          if (stdout) console.log(`[${folder}] stdout:`, stdout);
-          if (stderr) console.error(`[${folder}] stderr:`, stderr);
+          if (stdout) {
+            logger.debug('Extra resource build output', {
+              resource: folder,
+              output: stdout.trim(),
+            });
+          }
+          if (stderr) {
+            logger.warn('Extra resource build stderr', {
+              resource: folder,
+              output: stderr.trim(),
+            });
+          }
           if (error) {
             reject(new Error(`Build failed for extra-resource "${folder}": ${error.message}`));
           } else {
@@ -354,7 +381,10 @@ ${Object.entries(envConfigs)
 
     const existsControllerPath = await existsFile(originalControllerPath);
     if (existsControllerPath) {
-      console.log(originalControllerPath);
+      logger.debug('Copying module controller', {
+        module: usecaseConfig.module,
+        source: originalControllerPath,
+      });
 
       const controllerContent = await readFile(originalControllerPath, {
         encoding: 'utf-8',

--- a/builders/src/impl/module-lambda-aws/templates/helpers.ts
+++ b/builders/src/impl/module-lambda-aws/templates/helpers.ts
@@ -11,9 +11,6 @@ export type ConnectionConfig = {
 };
 
 export const responseMapper = (response: any) => {
-  console.log('Response ');
-  console.log(response);
-
   const body = response;
   const code = body['meta']['code'];
   const fragments = code.split(':') ?? ['-', '-'];
@@ -84,9 +81,6 @@ export function generate(
     Authorization: headers['Authorization'] ?? headers['authorization'] ?? '',
     'Content-Type': headers['Content-Type'] ?? headers['content-type'] ?? '',
   };
-  console.log('Nuevos headers');
-  console.log(newHeaders);
-
   const runtimeUrl =
     env == 'prod'
       ? 'https://api.skorify.cloud-manizales.com'

--- a/builders/src/impl/module-lambda-aws/templates/lambda-body.template
+++ b/builders/src/impl/module-lambda-aws/templates/lambda-body.template
@@ -1,4 +1,5 @@
 // handler.ts
+import type { Context } from 'aws-lambda';
 // import { APIGatewayProxyEvent } from "aws-lambda";
 // import { MethodMapper } from "@scifamek-open-source/iraca/web-api";
 import { IracaServer } from "@scifamek-open-source/iraca/web-api";
@@ -27,6 +28,57 @@ import {
   GetParameterCommand,
 } from '@aws-sdk/client-ssm';
 
+import { Logger } from '@aws-lambda-powertools/logger';
+
+const logger = new Logger({
+  serviceName: process.env.POWERTOOLS_SERVICE_NAME || 'skorify-{{MODULE}}',
+});
+
+const serializeError = (error: unknown): unknown => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return error;
+};
+
+const getBusinessContext = (payload: Record<string, unknown> | undefined) => {
+  const businessContext: Record<string, string | number> = {};
+  const keys = ['matchId', 'tournamentInstanceId', 'predictionId', 'userId'] as const;
+
+  for (const key of keys) {
+    const value = payload?.[key];
+
+    if (typeof value === 'string' || typeof value === 'number') {
+      businessContext[key] = value;
+    }
+  }
+
+  const nestedEntities = [
+    ['matchId', payload?.match],
+    ['tournamentInstanceId', payload?.tournamentInstance],
+    ['predictionId', payload?.prediction],
+    ['userId', payload?.user],
+  ] as const;
+
+  for (const [key, entity] of nestedEntities) {
+    if (businessContext[key] !== undefined || typeof entity !== 'object' || entity === null) {
+      continue;
+    }
+
+    const id = (entity as Record<string, unknown>).id;
+
+    if (typeof id === 'string' || typeof id === 'number') {
+      businessContext[key] = id;
+    }
+  }
+
+  return businessContext;
+};
 
 
 type LambdaEvent = {
@@ -47,7 +99,7 @@ function printDateDiff(title: string, initialTime: Date){
 
   const diferenciaMs = now.getTime() - initialTime.getTime();
 
-  console.log('** ',title,': ',diferenciaMs);
+  logger.debug('Timing checkpoint', { checkpoint: title, elapsedMs: diferenciaMs });
 
 }
 
@@ -67,7 +119,7 @@ function printDateDiff(title: string, initialTime: Date){
 
 
 async function init(){
-    
+
     if(!globalConfig['DBConfigObject']){
       const DBConfigObject = await secretManagerClient.send(
         new GetSecretValueCommand({
@@ -76,8 +128,8 @@ async function init(){
       );
 
       const externalDBConfig = DBConfigObject.SecretString;
-      const parsedDBSecrets = JSON.parse(externalDBConfig!);    
-      
+      const parsedDBSecrets = JSON.parse(externalDBConfig!);
+
       const dbClient = new DBClient({
         type: 'postgres',
         host: parsedDBSecrets.host,
@@ -92,13 +144,13 @@ async function init(){
 
         try {
           await dbClient.connect();
-          console.log('Database connected successfully');
+          logger.debug('Database connected successfully');
         } catch (error) {
-          console.error('Failed to connect to database:', error);
-          process.exit(1);
+          logger.error('Failed to connect to database', { error: serializeError(error) });
+          throw error;
         }
 
-   
+
 
       globalConfig['DBConfigObject'] = DBConfigObject;
       globalConfig['dbClient'] = dbClient;
@@ -119,84 +171,106 @@ const methodMapper = [
 const multiValueQueryUsecases = ['GetUsersByIdsUsecase', 'GetTeamByIdsUsecase'];
 
 
-export const handler = async (event: any) => {
+export const handler = async (event: any, context: Context) => {
   const initialTime = new Date();
-
-  await init();
-
-  const container = new IracaContainer();
-
-
-
-  container.add({
-    abstraction: StorageContract,
-    implementation: StorageImpl,
-  });
-
-  const eventBusConfig = {
-    eventBusName: BusParameterArn,
-    source: 'SkorifyBackend'
-  }
-
-  container.addValue({
-    id: 'eventBusConfig',
-    value: eventBusConfig,
-  });
-
-  container.add({
-    abstraction: EventBusContract,
-    implementation: EventBusImpl,
-    dependencies: ['eventBusConfig'],
-  });
-
-
- 
-
-
-
-  const headers = event.headers;
-  const method = getMethod(event)
-  const path = getPath(event);
-
-  const {DBConfigObject, dbClient} = globalConfig;
-
-  container.addValue({
-    id: 'DBClient',
-    value: dbClient,
-  });
-
-  container.addValue({
-    id: '{{MODULE_PASCAL}}Contract',
-    value: dbClient.{{MODULE_SERVICE}},
-  });
-
-  printDateDiff('Después de ir a AWS secretos', initialTime);
-
-  const identifier = "{{IDENTIFIER}}";
-
-      {{INJECTIONS}}
-
 
   const baseHeaders = {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
     'Access-Control-Allow-Headers': '*'
-  }
-  
+  };
+
+  let method = 'UNKNOWN';
+  let path = 'UNKNOWN';
+  let useCaseName: string | undefined;
+  let businessContext: Record<string, string | number> = {};
+
+  logger.addContext(context);
+  method = getMethod(event)
+  path = getPath(event);
+  const headers = event.headers ?? {};
+
   try {
+    await init();
 
-    const useCaseName = `${toPascalCase(path)}Usecase`
-    console.log(useCaseName);
-    console.log('useCase');
-    console.log(container.configsTable);
+    const container = new IracaContainer();
+
+
+
+    container.add({
+      abstraction: StorageContract,
+      implementation: StorageImpl,
+    });
+
+    const eventBusConfig = {
+      eventBusName: BusParameterArn,
+      source: 'SkorifyBackend'
+    }
+
+    container.addValue({
+      id: 'eventBusConfig',
+      value: eventBusConfig,
+    });
+
+    container.add({
+      abstraction: EventBusContract,
+      implementation: EventBusImpl,
+      dependencies: ['eventBusConfig'],
+    });
+
+
+
+
+
+
+    const { dbClient } = globalConfig;
+
+    container.addValue({
+      id: 'DBClient',
+      value: dbClient,
+    });
+
+    container.addValue({
+      id: '{{MODULE_PASCAL}}Contract',
+      value: dbClient.{{MODULE_SERVICE}},
+    });
+
+    printDateDiff('After AWS secrets', initialTime);
+
+    const identifier = "{{IDENTIFIER}}";
+
+        {{INJECTIONS}}
+
+
+
+    useCaseName = `${toPascalCase(path)}Usecase`
+    logger.debug('Resolving usecase', { method, path, usecase: useCaseName });
     const useCase = await container.getInstance<any>(useCaseName);
-    console.log(useCase);
+    logger.debug('Usecase resolved', {
+      usecase: useCaseName,
+      implementation: useCase?.constructor?.name,
+      found: Boolean(useCase),
+    });
 
-    printDateDiff('Obtención del caso de uso', initialTime);
+    printDateDiff('Usecase resolved', initialTime);
 
     if (!useCase) {
+      const durationMs = Date.now() - initialTime.getTime();
+      logger.warn('HTTP request completed', {
+        method,
+        path,
+        usecase: useCaseName,
+        statusCode: 404,
+        durationMs,
+        outcome: 'usecase_not_found',
+      });
+
       return {
         statusCode: 404,
+        headers: {
+          ...baseHeaders,
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({
           message: `Use case ${useCaseName} not found`,
         }),
@@ -210,25 +284,53 @@ export const handler = async (event: any) => {
 
 
     const payload = getPayload(event, strategy)
+    businessContext = getBusinessContext(payload);
+    logger.debug('Payload built', {
+      usecase: useCaseName,
+      strategy,
+      payloadKeys: Object.keys(payload ?? {}),
+      ...businessContext,
+    });
 
     const result = await useCase.call(payload)
 
-    printDateDiff('Después de finalizar el caso de uso CALL', initialTime);
-    
+    printDateDiff('Usecase call completed', initialTime);
+    const durationMs = Date.now() - initialTime.getTime();
 
-    console.log('Usecase result');
-    console.log(result);
+    if (useCaseName === 'MakePredictionUsecase') {
+      logger.info('Prediction outcome', {
+        ...businessContext,
+        predictedHomeScore: payload.homeScore,
+        predictedAwayScore: payload.awayScore,
+        outcome: result.eventName,
+        durationMs,
+      });
+    }
+
     const parsed = {
         data: result.payload,
         meta: {
           code: '{{MODULE_PASCAL}}:'+result.eventName
         }
       };
-    console.log(parsed);
     const parsedSTR = JSON.stringify(parsed);
-    console.log(parsedSTR);
-    
-    printDateDiff('Respondiendo', initialTime);
+    logger.debug('Response serialized', {
+      usecase: useCaseName,
+      eventName: result.eventName,
+      responseBytes: parsedSTR.length,
+    });
+
+    logger.info('HTTP request completed', {
+      method,
+      path,
+      usecase: useCaseName,
+      ...businessContext,
+      statusCode: 200,
+      durationMs,
+      outcome: result.eventName,
+    });
+
+    printDateDiff('Responding', initialTime);
 
     return {
       statusCode: 200,
@@ -239,6 +341,17 @@ export const handler = async (event: any) => {
       body: parsedSTR,
     }
   } catch (error) {
+    logger.error('HTTP request failed', {
+      error: serializeError(error),
+      path,
+      method,
+      usecase: useCaseName,
+      ...businessContext,
+      statusCode: 500,
+      durationMs: Date.now() - initialTime.getTime(),
+      outcome: 'unhandled_error',
+    });
+
     return {
       statusCode: 500,
       headers: {
@@ -247,10 +360,7 @@ export const handler = async (event: any) => {
       },
       body: JSON.stringify({
         message: 'Internal server error',
-        error:
-          error instanceof Error
-            ? error.message
-            : 'Unknown error',
+        requestId: context.awsRequestId,
       }),
     }
   }

--- a/builders/src/impl/module-lambda-aws/templates/lambda-body.template
+++ b/builders/src/impl/module-lambda-aws/templates/lambda-body.template
@@ -235,6 +235,11 @@ export const handler = async (event: any, context: Context) => {
       value: dbClient.{{MODULE_SERVICE}},
     });
 
+    container.addValue({
+      id: 'Logger',
+      value: logger,
+    });
+
     printDateDiff('After AWS secrets', initialTime);
 
     const identifier = "{{IDENTIFIER}}";

--- a/builders/src/impl/module-lambda-aws/templates/package.template.json
+++ b/builders/src/impl/module-lambda-aws/templates/package.template.json
@@ -8,6 +8,7 @@
     "copy-template": "copyfiles template.yaml ./dist"
   },
   "dependencies": {
+    "@aws-lambda-powertools/logger": "^2.33.1",
     "@scifamek-open-source/iraca": "9.2.0",
     "@skorify/domain": "github:aws-ug-manizales/Skorify_Domain#main",
     "@skorify/shared": "github:aws-ug-manizales/Skorify_Shared#main",
@@ -19,6 +20,7 @@
   },
   "devDependencies": {
     "copyfiles": "^2.4.1",
+    "@types/aws-lambda": "^8.10.161",
     "@types/node": "22.5.0",
     "ts-node": "10.9.2",
     "typescript": "5.8.3",

--- a/builders/src/impl/module-lambda-aws/templates/package.template.json
+++ b/builders/src/impl/module-lambda-aws/templates/package.template.json
@@ -12,7 +12,7 @@
     "@scifamek-open-source/iraca": "9.2.0",
     "@skorify/domain": "github:aws-ug-manizales/Skorify_Domain#main",
     "@skorify/shared": "github:aws-ug-manizales/Skorify_Shared#main",
-    "@skorify/data": "github:aws-ug-manizales/Skorify_Data#v1.4.4",
+    "@skorify/data": "github:aws-ug-manizales/Skorify_Data#v1.4.5",
     "@aws-sdk/client-lambda": "^3.600.0",
     "@aws-sdk/client-ssm": "3.1050.0",
     "@aws-sdk/client-secrets-manager": "3.1050.0",

--- a/builders/src/impl/single-lambda-aws/index.ts
+++ b/builders/src/impl/single-lambda-aws/index.ts
@@ -221,6 +221,12 @@ ${resourcesYML.join("\n")}`,
             const name = param.name.getText();
             const type = param.type?.getText() ?? "any";
             dependencies.push(type);
+            // `Logger` ya lo importa el template y se registra con addValue
+            // (Logger.name === "Logger" resuelve la dependencia); no re-importar
+            // para evitar un import duplicado.
+            if (type === "Logger") {
+              return;
+            }
             this.addImport(imports, usecasesConfig, type, source);
             if (type.includes("Usecase")) {
               injections.push(`

--- a/builders/src/impl/single-lambda-aws/index.ts
+++ b/builders/src/impl/single-lambda-aws/index.ts
@@ -14,6 +14,7 @@ import {
   UsecaseInfo,
   UsecasesInfo,
 } from "../../general/helpers";
+import { logger } from "../../general/logger";
 
 type Templates = {
   packageTemplate: string;
@@ -27,7 +28,10 @@ export class SingleLambdaAWSBuilder extends Builder {
   async build(config: BuilderConfiguration, env: string): Promise<void> {
     const usecases = await this.getUsecases(config.serverFolder);
 
-    console.log(usecases);
+    logger.debug("Single Lambda usecases discovered", {
+      usecaseCount: usecases.length,
+      modules: [...new Set(usecases.map((usecase) => usecase.module))],
+    });
 
     const myFolder = "single-lambda-aws";
 

--- a/builders/src/impl/single-lambda-aws/templates/lambda-body.template
+++ b/builders/src/impl/single-lambda-aws/templates/lambda-body.template
@@ -38,6 +38,8 @@ export const handler = async (event: any, context: Context) => {
   ];
     const container = new IracaContainer();
 
+    container.addValue({ id: "Logger", value: logger });
+
   {{INJECTIONS}}
 
     container.add({

--- a/builders/src/impl/single-lambda-aws/templates/lambda-body.template
+++ b/builders/src/impl/single-lambda-aws/templates/lambda-body.template
@@ -1,45 +1,89 @@
 // handler.ts
+import { Logger } from '@aws-lambda-powertools/logger';
+import type { Context } from 'aws-lambda';
 // import { APIGatewayProxyEvent } from "aws-lambda";
 // import { MethodMapper } from "@scifamek-open-source/iraca/web-api";
 import { IracaContainer } from "@scifamek-open-source/iraca/dependency-injection";
 import { generate } from "./helpers";
 import { {{MODULE_PASCAL}}Repository } from "./{{MODULE}}.repository";
 
+const logger = new Logger({
+  serviceName: process.env.POWERTOOLS_SERVICE_NAME || 'skorify-{{MODULE}}',
+});
+
+const serializeError = (error: unknown): unknown => {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack };
+  }
+
+  return error;
+};
+
 {{IMPORTS}}
 
-export const handler = async (event: any) => {
-  const name = event.queryStringParameters?.name ?? "World";
+export const handler = async (event: any, context: Context) => {
+  const startedAt = Date.now();
+  logger.addContext(context);
 
-  const identifier = "{{IDENTIFIER}}";
+  try {
+    const name = event.queryStringParameters?.name ?? "World";
 
-    const methodMapper: any = [
-  {
-    method: "get",
-    patterns: [/[\w]+/],
-  },
-];
-  const container = new IracaContainer();
+    const identifier = "{{IDENTIFIER}}";
 
-{{INJECTIONS}}
-
-  container.add({
-    abstraction: {{MAIN_USECASE}},
-    implementation: {{MAIN_USECASE_IMPL}},
-    dependencies: {{MAIN_USECASE_DEPENDENCIES}},
-  });
-
-  const instance = await container.getInstance<{{MAIN_USECASE}}>({{MAIN_USECASE}});
-  const param = {}
-  const usecaseResponse = await instance.call(param as any);
-  const response = {
-    meta: {
-      code: `${identifier}:${usecaseResponse.eventName}`,
+      const methodMapper: any = [
+    {
+      method: "get",
+      patterns: [/[\w]+/],
     },
-    data: usecaseResponse.payload 
-  };
+  ];
+    const container = new IracaContainer();
 
-  return {
-    statusCode: 200,
-    body: JSON.stringify(response),
-  };
+  {{INJECTIONS}}
+
+    container.add({
+      abstraction: {{MAIN_USECASE}},
+      implementation: {{MAIN_USECASE_IMPL}},
+      dependencies: {{MAIN_USECASE_DEPENDENCIES}},
+    });
+
+    const instance = await container.getInstance<{{MAIN_USECASE}}>({{MAIN_USECASE}});
+    const param = {}
+    const usecaseResponse = await instance.call(param as any);
+    const response = {
+      meta: {
+        code: `${identifier}:${usecaseResponse.eventName}`,
+      },
+      data: usecaseResponse.payload
+    };
+
+    logger.info('Lambda request completed', {
+      usecase: '{{MAIN_USECASE}}',
+      outcome: usecaseResponse.eventName,
+      statusCode: 200,
+      durationMs: Date.now() - startedAt,
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(response),
+    };
+  } catch (error) {
+    logger.error('Lambda request failed', {
+      usecase: '{{MAIN_USECASE}}',
+      statusCode: 500,
+      durationMs: Date.now() - startedAt,
+      error: serializeError(error),
+    });
+
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: 'Internal server error',
+        requestId: context.awsRequestId,
+      }),
+    };
+  }
 };

--- a/builders/src/impl/single-lambda-aws/templates/package.template.json
+++ b/builders/src/impl/single-lambda-aws/templates/package.template.json
@@ -9,12 +9,14 @@
 
   },
   "dependencies": {
+    "@aws-lambda-powertools/logger": "^2.33.1",
     "@scifamek-open-source/iraca": "9.1.0",
     "@skorify/domain": "link:../../../../domain/dist",
     "@aws-sdk/client-lambda": "^3.600.0"
   },
   "devDependencies": {
     "copyfiles": "^2.4.1",
+    "@types/aws-lambda": "^8.10.161",
     "@types/node": "22.5.0",
     "ts-node": "10.9.2",
     "typescript": "5.8.3",

--- a/builders/src/index.ts
+++ b/builders/src/index.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import { exit } from 'node:process';
 import { BuilderConfiguration } from './general/builder';
+import { logger, serializeError } from './general/logger';
 import { BuilderNamesMapper, ValidBuilderNames } from './general/models';
 import { ModuleLambdaAWSBuilder } from './impl/module-lambda-aws';
 import { SingleLambdaAWSBuilder } from './impl/single-lambda-aws';
@@ -28,7 +29,11 @@ async function main() {
   try {
     await builder?.build(config, env);
   } catch (e) {
-    console.error(e);
+    logger.error('Builder failed', {
+      builder: way,
+      environment: env,
+      error: serializeError(e),
+    });
     exit(1);
   }
 }

--- a/server/jest.config.cjs
+++ b/server/jest.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['<rootDir>/test/**/*.spec.ts'],
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  setupFiles: ['<rootDir>/test/setup-crypto.ts'],
 
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.jest.json' }],

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "start:heroku": "node dist/src/index.js"
   },
   "dependencies": {
+    "@aws-lambda-powertools/logger": "^2.33.1",
     "@scifamek-open-source/iraca": "9.2.0",
     "@scifamek-open-source/logger": "1.1.2",
     "@skorify/data": "github:aws-ug-manizales/Skorify_Data#v1.4.1",
@@ -25,6 +26,7 @@
     "@skorify/shared": "github:aws-ug-manizales/Skorify_Shared#main"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.161",
     "@types/jest": "^30.0.0",
     "@types/node": "22.5.0",
     "copyfiles": "^2.4.1",

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
     "@aws-lambda-powertools/logger": "^2.33.1",
     "@scifamek-open-source/iraca": "9.2.0",
     "@scifamek-open-source/logger": "1.1.2",
-    "@skorify/data": "github:aws-ug-manizales/Skorify_Data#v1.4.1",
+    "@skorify/data": "github:aws-ug-manizales/Skorify_Data#v1.4.5",
     "@skorify/domain": "github:aws-ug-manizales/Skorify_Domain#main",
     "@skorify/shared": "github:aws-ug-manizales/Skorify_Shared#main"
   },

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aws-lambda-powertools/logger':
+        specifier: ^2.33.1
+        version: 2.33.1
       '@scifamek-open-source/iraca':
         specifier: 9.2.0
         version: 9.2.0
@@ -19,11 +22,14 @@ importers:
         version: skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3))
       '@skorify/domain':
         specifier: github:aws-ug-manizales/Skorify_Domain#main
-        version: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8
+        version: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f
       '@skorify/shared':
         specifier: github:aws-ug-manizales/Skorify_Shared#main
         version: https://codeload.github.com/aws-ug-manizales/Skorify_Shared/tar.gz/18c345573303ff286ddd9e0aa3add38c4e291669
     devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8.10.161
+        version: 8.10.161
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -73,6 +79,20 @@ packages:
 
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-lambda-powertools/commons@2.33.1':
+    resolution: {integrity: sha512-edzvz+zqBl8p9J2Cgo1rFmhd+3ANqr0PQDqowElS3CJ10ioHN2wUYiANGxfalcgbB8ulZxGkRbK3wvEEziV/5w==}
+
+  '@aws-lambda-powertools/logger@2.33.1':
+    resolution: {integrity: sha512-DDnKcv2zghslh2AtrVsa4wHcAuI5M7+JlX65CgdXLk2th0Nr0octJQq0f4Bnp+DzuwFynmH4GJqsBe33rZapAw==}
+    peerDependencies:
+      '@aws-lambda-powertools/jmespath': 2.33.1
+      '@middy/core': 4.x || 5.x || 6.x || 7.x
+    peerDependenciesMeta:
+      '@aws-lambda-powertools/jmespath':
+        optional: true
+      '@middy/core':
+        optional: true
 
   '@aws-sdk/checksums@3.1000.2':
     resolution: {integrity: sha512-PIha+kauTbp6IRmOpYktPTrlfrrSqDVixvhO/EUOFOf62DPX81CaJoHJreuA1m9HYpSKyXf99BKjU1dvJPeUfw==}
@@ -493,8 +513,8 @@ packages:
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
-  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8':
-    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8}
+  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f':
+    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f}
     version: 1.2.0
 
   '@skorify/shared@https://codeload.github.com/aws-ug-manizales/Skorify_Shared/tar.gz/18c345573303ff286ddd9e0aa3add38c4e291669':
@@ -554,6 +574,9 @@ packages:
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/aws-lambda@8.10.161':
+    resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2183,6 +2206,15 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-lambda-powertools/commons@2.33.1':
+    dependencies:
+      '@aws/lambda-invoke-store': 0.2.4
+
+  '@aws-lambda-powertools/logger@2.33.1':
+    dependencies:
+      '@aws-lambda-powertools/commons': 2.33.1
+      '@aws/lambda-invoke-store': 0.2.4
+
   '@aws-sdk/checksums@3.1000.2':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
@@ -2873,7 +2905,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8': {}
+  '@skorify/domain@https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f': {}
 
   '@skorify/shared@https://codeload.github.com/aws-ug-manizales/Skorify_Shared/tar.gz/18c345573303ff286ddd9e0aa3add38c4e291669':
     dependencies:
@@ -2882,7 +2914,7 @@ snapshots:
       '@aws-sdk/client-s3': 3.1063.0
       '@aws-sdk/client-sns': 3.1063.0
       '@aws-sdk/s3-request-presigner': 3.1063.0
-      '@skorify/domain': https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8
+      '@skorify/domain': https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f
 
   '@smithy/core@3.24.6':
     dependencies:
@@ -2946,6 +2978,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aws-lambda@8.10.161': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4263,7 +4297,7 @@ snapshots:
 
   skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3)):
     dependencies:
-      '@skorify/domain': https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/69bf3096e52314e96e36e59cf442cdb44558ffc8
+      '@skorify/domain': https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f
       class-transformer: 0.5.1
       class-validator: 0.15.1
       knex: 3.2.10(pg@8.21.0)

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       '@skorify/data':
-        specifier: github:aws-ug-manizales/Skorify_Data#v1.4.1
-        version: skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3))
+        specifier: github:aws-ug-manizales/Skorify_Data#v1.4.5
+        version: skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/a7794a3c6b26992cb9d3fa85d8cd84b723cfc963(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3))
       '@skorify/domain':
         specifier: github:aws-ug-manizales/Skorify_Domain#main
         version: https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f
@@ -1805,8 +1805,8 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
-  skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178:
-    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178}
+  skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/a7794a3c6b26992cb9d3fa85d8cd84b723cfc963:
+    resolution: {tarball: https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/a7794a3c6b26992cb9d3fa85d8cd84b723cfc963}
     version: 1.0.0-beta
 
   slash@3.0.0:
@@ -4295,7 +4295,7 @@ snapshots:
     dependencies:
       semver: 7.8.2
 
-  skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/12f06627c7f26d8c3343ea5ab126befd3e18a178(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3)):
+  skorifydata@https://codeload.github.com/aws-ug-manizales/Skorify_Data/tar.gz/a7794a3c6b26992cb9d3fa85d8cd84b723cfc963(ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3)):
     dependencies:
       '@skorify/domain': https://codeload.github.com/aws-ug-manizales/Skorify_Domain/tar.gz/de097216dce6e755b04e9da9023012694830166f
       class-transformer: 0.5.1

--- a/server/src/config/logger.ts
+++ b/server/src/config/logger.ts
@@ -1,0 +1,17 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+
+export const logger = new Logger({
+  serviceName: process.env.POWERTOOLS_SERVICE_NAME || 'skorify-backend',
+});
+
+export const serializeError = (error: unknown): unknown => {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return error;
+};

--- a/server/src/config/on-load-iraca.ts
+++ b/server/src/config/on-load-iraca.ts
@@ -4,6 +4,7 @@ import { EventBusContract, StorageContract } from '@skorify/domain/core';
 import { CalculateMatchScoreUsecase, ReactiveClosedMatchDomainEvent } from '@skorify/domain/match';
 import { EventBusMemoryImpl, Queue, StorageMemoryImpl } from '@skorify/shared';
 import { join } from 'path';
+import { logger, serializeError } from './logger';
 
 type DatabaseConfig = {
   host: string;
@@ -34,9 +35,18 @@ type Injections = {
   [key: string]: unknown;
 };
 export const onLoadIraca = async (container: IracaContainer, injections: Injections) => {
-  console.log(injections);
   const { database } = injections;
   const { host, port, username, engine, password, name, logging, enabled } = database;
+  logger.debug('Loading Iraca container', {
+    database: {
+      enabled,
+      engine,
+      host,
+      port,
+      name,
+      logging,
+    },
+  });
 
   const dataPath = join(__dirname, '../../../shared/src/data');
 
@@ -53,9 +63,9 @@ export const onLoadIraca = async (container: IracaContainer, injections: Injecti
     // Connect to database
     try {
       await dbClient.connect();
-      console.log('Database connected successfully');
+      logger.debug('Database connected successfully');
     } catch (error) {
-      console.error('Failed to connect to database:', error);
+      logger.error('Failed to connect to database', { error: serializeError(error) });
       process.exit(1);
     }
 
@@ -137,16 +147,28 @@ export const onLoadIraca = async (container: IracaContainer, injections: Injecti
   const queue = new Queue();
 
   queue.subscribe(ReactiveClosedMatchDomainEvent.eventName, async (data) => {
-    console.log('Hola mundo', data);
+    logger.debug('Reactive match close event received', {
+      matchId: data.match?.id,
+      tournamentInstanceId: data.tournamentInstance?.id,
+    });
 
-    const usecase = await container.getInstance<CalculateMatchScoreUsecase>(
-      CalculateMatchScoreUsecase,
-    );
-    if (usecase) {
-      await usecase.call({
-        matchId: data.match.id,
-        tournamentInstanceId: data.tournamentInstance.id,
+    try {
+      const usecase = await container.getInstance<CalculateMatchScoreUsecase>(
+        CalculateMatchScoreUsecase,
+      );
+      if (usecase) {
+        await usecase.call({
+          matchId: data.match.id,
+          tournamentInstanceId: data.tournamentInstance.id,
+        });
+      }
+    } catch (error) {
+      logger.error('Reactive match score calculation failed', {
+        matchId: data.match?.id,
+        tournamentInstanceId: data.tournamentInstance?.id,
+        error: serializeError(error),
       });
+      throw error;
     }
   });
 

--- a/server/src/config/on-load-iraca.ts
+++ b/server/src/config/on-load-iraca.ts
@@ -48,6 +48,11 @@ export const onLoadIraca = async (container: IracaContainer, injections: Injecti
     },
   });
 
+  container.addValue({
+    id: 'Logger',
+    value: logger,
+  });
+
   const dataPath = join(__dirname, '../../../shared/src/data');
 
   if (enabled != 'true') {

--- a/server/src/features/match/usecases/calculate-match-score.usecase-impl.ts
+++ b/server/src/features/match/usecases/calculate-match-score.usecase-impl.ts
@@ -23,6 +23,7 @@ import {
   UpdateUserEnrollmentUsecase,
   UserEnrollmentEntity,
 } from '@skorify/domain/user-enrollment';
+import { Logger } from '@aws-lambda-powertools/logger';
 
 export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
   constructor(
@@ -32,6 +33,7 @@ export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
     private getPredictionsByMatchAndTournamentInstanceUsecase: GetPredictionsByMatchAndTournamentInstanceUsecase,
     private updateUserEnrollmentUsecase: UpdateUserEnrollmentUsecase,
     private getEnrollmentsWithoutPredictionUsecase: GetEnrollmentsWithoutPredictionUsecase,
+    private logger: Logger,
   ) {
     super();
   }
@@ -103,6 +105,12 @@ export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
     });
 
     if (userEnrollmentDE.isNot(GottenUserEnrollmentDomainEvent)) {
+      this.logger.warn('Prediction score skipped', {
+        matchId: match.id,
+        predictionId: prediction.id,
+        userEnrollmentId: prediction.userEnrollmentId,
+        reason: 'enrollment_not_found',
+      });
       return;
     }
 

--- a/server/src/features/match/usecases/calculate-match-score.usecase-impl.ts
+++ b/server/src/features/match/usecases/calculate-match-score.usecase-impl.ts
@@ -45,13 +45,8 @@ export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
       return MatchDoesNotExistDomainEvent();
     }
 
-    if(match.status == MatchStatus.Calculated) {
-      return MatchAlreadyCalculatedDomainEvent(match);
-
-    }
-    if(match.status !== MatchStatus.Finished) {
+    if (match.status !== MatchStatus.Finished) {
       return MatchHasNotFinishedDomainEvent(match);
-
     }
 
     const predictionsDE = await this.getPredictionsByMatchAndTournamentInstanceUsecase.call({
@@ -59,15 +54,17 @@ export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
       tournamentInstanceId,
     });
     const predictions: PredictionEntity[] = predictionsDE.payload as PredictionEntity[];
+    const pendingPredictions = predictions.filter((prediction) => !prediction.isCalculated);
 
-    if (predictions && predictions.length > 0) {
-      await this.calculateScores(match, predictions);
+    if (predictions.length > 0 && pendingPredictions.length === 0) {
+      return MatchAlreadyCalculatedDomainEvent(match);
+    }
+
+    if (pendingPredictions.length > 0) {
+      await this.calculateScores(match, pendingPredictions);
     }
 
     await this.resetStreakForMissingPredictions(matchId, tournamentInstanceId);
-
-    match.status = MatchStatus.Calculated;
-    await this.matchContract.modify(match);
 
     return CalculatedMatchDomainEvent(match);
   }
@@ -94,6 +91,7 @@ export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
       awayScore: prediction.awayScore,
       earnedPoints: prediction.earnedPoints,
       hasExactResult: prediction.hasExactResult,
+      isCalculated: prediction.isCalculated,
     });
 
     const clonedPrediction = clonedPredictionDE.payload as PredictionEntity;

--- a/server/src/features/match/usecases/close-match.usecase-impl.ts
+++ b/server/src/features/match/usecases/close-match.usecase-impl.ts
@@ -40,7 +40,6 @@ export class CloseMatchUsecaseImpl extends CloseMatchUsecase {
       return matchDE;
     }
     const match: MatchEntity = matchDE.payload;
-    console.log(match);
     const status = match.status ?? match['_status'];
 
     if (status == MatchStatus.Finished) {

--- a/server/src/features/prediction/usecases/edit-prediction-directly.usecase-impl.ts
+++ b/server/src/features/prediction/usecases/edit-prediction-directly.usecase-impl.ts
@@ -34,6 +34,7 @@ export class EditPredictionDirectlyUsecaseImpl extends EditPredictionDirectlyUse
     prediction.homeScore = homeScore;
     prediction.earnedPoints = earnedPoints;
     prediction.hasExactResult = hasExactResult;
+    prediction.isCalculated = true;
 
     const edited = await this.predictionContract.modify(prediction);
 

--- a/server/src/features/prediction/usecases/make-prediction.usecase-impl.ts
+++ b/server/src/features/prediction/usecases/make-prediction.usecase-impl.ts
@@ -102,6 +102,7 @@ export class MakePredictionUsecaseImpl extends MakePredictionUsecase {
       homeScore,
       earnedPoints: 0,
       hasExactResult: false,
+      isCalculated: false,
       userEnrollmentId: userEnrollment.userEnrollmentId,
       createdAt: new Date(),
     });

--- a/server/src/features/prediction/usecases/simulate-prediction.usecase-impl.ts
+++ b/server/src/features/prediction/usecases/simulate-prediction.usecase-impl.ts
@@ -13,25 +13,17 @@ export class SimulatePredictionUsecaseImpl extends SimulatePredictionUsecase {
   }
 
   async call(param: SimulatePredictionParam): Promise<DomainEvent> {
-    const {
-      predictionHomeScore, predictionAwayScore,
-      matchHomeScore, matchAwayScore,
-      streak
-    } = param;
+    const { predictionHomeScore, predictionAwayScore, matchHomeScore, matchAwayScore, streak } =
+      param;
 
-    const enrollmentDE = UserEnrollmentEntity.forSimulation({ streak, });
+    const enrollmentDE = UserEnrollmentEntity.forSimulation({ streak });
     const mockEnrollment = enrollmentDE.payload as UserEnrollmentEntity;
     const streakBonusPoints = mockEnrollment.getStreakBonusPoints();
-    console.log("predictionHomeScore", predictionHomeScore)
-    console.log("predictionAwayScore", predictionAwayScore)
-    console.log("matchHomeScore", matchHomeScore)
-    console.log("matchAwayScore", matchAwayScore)
-    console.log("streak", streak)
     const prediction = PredictionEntity.forSimulation({
-      homeScore: predictionHomeScore, awayScore: predictionAwayScore
+      homeScore: predictionHomeScore,
+      awayScore: predictionAwayScore,
     });
     const result = prediction.calculateScore(matchAwayScore, matchHomeScore, streakBonusPoints);
-    console.log("result", result)
 
     return SimulatedPredictionDomainEvent({
       total: prediction.earnedPoints,

--- a/server/src/features/team/usecases/create-team.usecase-impl.ts
+++ b/server/src/features/team/usecases/create-team.usecase-impl.ts
@@ -26,7 +26,6 @@ export class CreateTeamUsecaseImpl extends CreateTeamUsecase {
     if (tournamentDE.isNot(GottenTournamentDomainEvent)) {
       return tournamentDE;
     }
-    console.log(tournamentDE.payload);
 
     const teams = await this.teamContract.filter({
       where: {
@@ -34,7 +33,6 @@ export class CreateTeamUsecaseImpl extends CreateTeamUsecase {
         tournamentId,
       },
     });
-    console.log(teams);
 
     if (teams.length) {
       return TeamWithThatNameAlreadyExistsDomainEvent(teams[0]);

--- a/server/src/features/tournament-instance/usecases/create-tournament-instance.usecase-impl.ts
+++ b/server/src/features/tournament-instance/usecases/create-tournament-instance.usecase-impl.ts
@@ -33,7 +33,6 @@ export class CreateTournamentInstanceUsecaseImpl extends CreateTournamentInstanc
     //   tournamentId,
     // });
 
-    // console.log('tournamentDE', tournamentDE);
     // if (tournamentDE.isNot(GottenTournamentDomainEvent)) {
     //   return tournamentDE;
     // }

--- a/server/src/features/tournament-instance/usecases/get-current-ranking.usecase-impl.ts
+++ b/server/src/features/tournament-instance/usecases/get-current-ranking.usecase-impl.ts
@@ -54,9 +54,7 @@ export class GetCurrentRankingUsecaseImpl extends GetCurrentRankingUsecase {
     const pendingUserEnrollments = userEnrollments.filter((ue) => ue.currentPosition == null);
 
     const orderedUserEnrollments = [...rankedUserEnrollmentsSorted, ...pendingUserEnrollments];
-    console.log('orderedUserEnrollments', orderedUserEnrollments);
     const userIds = orderedUserEnrollments.map((ue) => ue.userId);
-    console.log('userIds', userIds);
     const ranking: RankingItem[] = [];
 
     const allUsersDE = await this.getUsersByIdsUsecase.call({

--- a/server/src/features/tournament-instance/usecases/get-tournament-instance-by-invite-code.usecase-impl.ts
+++ b/server/src/features/tournament-instance/usecases/get-tournament-instance-by-invite-code.usecase-impl.ts
@@ -30,8 +30,6 @@ export class GetTournamentInstanceByInviteCodeUsecaseImpl extends GetTournamentI
       };
     }
     const tournamentInstances = await this.tournamentInstanceContract.filter(filters);
-    console.log({tournamentInstances});
-    
 
     if (!tournamentInstances.length) {
       return NotGottenTournamentInstanceDomainEvent();

--- a/server/src/features/user-enrollment/usecases/get-user-enrollments-by-tournament-instance-id.usecase-impl.ts
+++ b/server/src/features/user-enrollment/usecases/get-user-enrollments-by-tournament-instance-id.usecase-impl.ts
@@ -1,5 +1,4 @@
 import { DomainEvent } from '@skorify/domain/core';
-
 import {
   GetUserEnrollmentsByTournamentInstanceIdParam,
   GetUserEnrollmentsByTournamentInstanceIdUsecase,
@@ -14,8 +13,6 @@ export class GetUserEnrollmentsByTournamentInstanceIdUsecaseImpl extends GetUser
   }
 
   async call(param: GetUserEnrollmentsByTournamentInstanceIdParam): Promise<DomainEvent> {
-    console.log('GetUserEnrollmentsByTournamentInstanceIdParam');
-    console.log(param);
     const { tournamentInstanceId } = param;
 
     if (!tournamentInstanceId) {

--- a/server/src/features/user/usecases/get-users-by-ids.usecase-impl.ts
+++ b/server/src/features/user/usecases/get-users-by-ids.usecase-impl.ts
@@ -14,9 +14,7 @@ export class GetUsersByIdsUsecaseImpl extends GetUsersByIdsUsecase {
   async call(param: GetUsersByIdsParam): Promise<DomainEvent> {
     const { userIds } = param;
 
-    console.log('userIds', userIds);
-    const parsed= Array.isArray(userIds) ? userIds : [userIds];
-    console.log('parsed', parsed);
+    const parsed = Array.isArray(userIds) ? userIds : [userIds];
     const promises = parsed.map((userId) => this.userContract.getById(userId));
 
     const usersInDB = await Promise.all(promises);

--- a/server/test/features/match/usecases/calculate-match-score.usecase-impl.spec.ts
+++ b/server/test/features/match/usecases/calculate-match-score.usecase-impl.spec.ts
@@ -1,21 +1,31 @@
-import { CalculateMatchScoreUsecaseImpl } from '../../../../src/features/match/usecases/calculate-match-score.usecase-impl';
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Id } from '@skorify/domain/core';
 import {
+  CalculatedMatchDomainEvent,
+  MatchAlreadyCalculatedDomainEvent,
   MatchContract,
-  MatchEntity,
-  GottenMatchDomainEvent,
   MatchDoesNotExistDomainEvent,
+  MatchEntity,
+  MatchHasNotFinishedDomainEvent,
+  MatchStatus,
 } from '@skorify/domain/match';
-import { PredictionContract, PredictionEntity } from '@skorify/domain/prediction';
 import {
-  GetUserEnrollmentByIdUsecase,
-  UpdateUserEnrollmentUsecase,
+  EditPredictionDirectlyUsecase,
+  GetPredictionsByMatchAndTournamentInstanceUsecase,
+  GottenPredictionsByMatchAndTournamentInstanceDomainEvent,
+  PredictionEntity,
+} from '@skorify/domain/prediction';
+import {
   GetEnrollmentsWithoutPredictionUsecase,
+  GetUserEnrollmentByIdUsecase,
   GottenUserEnrollmentDomainEvent,
   GottenUserEnrollmentsDomainEvent,
-  UserEnrollmentEntity,
+  NotGottenUserEnrollmentDomainEvent,
   SavedUserEnrollmentDomainEvent,
+  UpdateUserEnrollmentUsecase,
+  UserEnrollmentEntity,
 } from '@skorify/domain/user-enrollment';
-import { Id } from '@skorify/domain/core';
+import { CalculateMatchScoreUsecaseImpl } from '../../../../src/features/match/usecases/calculate-match-score.usecase-impl';
 
 describe('CalculateMatchScoreUsecaseImpl', () => {
   const matchId = '11111111-1111-1111-1111-111111111111' as Id;
@@ -23,36 +33,50 @@ describe('CalculateMatchScoreUsecaseImpl', () => {
   const enrollmentId = '33333333-3333-3333-3333-333333333333' as Id;
   const missingEnrollmentId = '44444444-4444-4444-4444-444444444444' as Id;
 
-  function makeMockMatchContract(match: MatchEntity | null): MatchContract {
+  function makeMatchContract(match: MatchEntity | null): MatchContract {
     return {
       getById: jest.fn().mockResolvedValue(match),
+      modify: jest.fn().mockImplementation((m: MatchEntity) => Promise.resolve(m)),
     } as unknown as MatchContract;
   }
 
-  function makeMockPredictionContract(predictions: PredictionEntity[]): PredictionContract {
+  function makeEditPredictionDirectly(): EditPredictionDirectlyUsecase {
     return {
-      filter: jest.fn().mockResolvedValue(predictions),
-      modify: jest
-        .fn()
-        .mockImplementation((id: string, ent: PredictionEntity) => Promise.resolve(ent)),
-    } as unknown as PredictionContract;
+      call: jest.fn().mockResolvedValue(undefined),
+    } as unknown as EditPredictionDirectlyUsecase;
   }
 
-  function makeMockGetUserEnrollmentUsecase(
-    enrollment: UserEnrollmentEntity,
-  ): GetUserEnrollmentByIdUsecase {
+  function makeGetPredictions(
+    predictions: PredictionEntity[],
+  ): GetPredictionsByMatchAndTournamentInstanceUsecase {
     return {
-      call: jest.fn().mockResolvedValue(GottenUserEnrollmentDomainEvent(enrollment)),
+      call: jest
+        .fn()
+        .mockResolvedValue(GottenPredictionsByMatchAndTournamentInstanceDomainEvent(predictions)),
+    } as unknown as GetPredictionsByMatchAndTournamentInstanceUsecase;
+  }
+
+  function makeGetUserEnrollment(found: boolean): GetUserEnrollmentByIdUsecase {
+    return {
+      call: jest
+        .fn()
+        .mockResolvedValue(
+          found
+            ? GottenUserEnrollmentDomainEvent(buildFakeEnrollment(enrollmentId))
+            : NotGottenUserEnrollmentDomainEvent(),
+        ),
     } as unknown as GetUserEnrollmentByIdUsecase;
   }
 
-  function makeMockUpdateUserEnrollmentUsecase(): UpdateUserEnrollmentUsecase {
+  function makeUpdateUserEnrollment(): UpdateUserEnrollmentUsecase {
     return {
-      call: jest.fn().mockResolvedValue(SavedUserEnrollmentDomainEvent),
+      call: jest
+        .fn()
+        .mockResolvedValue(SavedUserEnrollmentDomainEvent(buildFakeEnrollment(enrollmentId))),
     } as unknown as UpdateUserEnrollmentUsecase;
   }
 
-  function makeMockGetEnrollmentsWithoutPredictionUsecase(
+  function makeGetMissingEnrollments(
     enrollments: UserEnrollmentEntity[],
   ): GetEnrollmentsWithoutPredictionUsecase {
     return {
@@ -60,55 +84,60 @@ describe('CalculateMatchScoreUsecaseImpl', () => {
     } as unknown as GetEnrollmentsWithoutPredictionUsecase;
   }
 
-  function buildFakeMatch(awayScore?: number, homeScore?: number): MatchEntity {
-    const futureDate = new Date();
-    futureDate.setHours(futureDate.getHours() + 1);
+  function makeLogger() {
+    return {
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    } as unknown as Logger;
+  }
 
+  function buildFakeMatch(): MatchEntity {
     const match = MatchEntity.build({
       id: matchId,
       homeTeamId: 'h-1' as Id,
       awayTeamId: 'a-1' as Id,
       tournamentId: 't-1' as Id,
-      kickOff: futureDate,
-      homeScore: homeScore ?? 0,
-      awayScore: awayScore ?? 0,
+      kickOff: new Date(),
+      homeScore: 1,
+      awayScore: 2,
+      status: MatchStatus.Finished,
       createdAt: new Date(),
     }).payload;
-
-    if (awayScore === undefined) {
-      match.awayScore = undefined;
-    }
-    if (homeScore === undefined) {
-      match.homeScore = undefined;
-    }
-
+    match.status = MatchStatus.Finished;
     return match;
   }
 
-  function buildFakePrediction(): PredictionEntity {
-    const pred = PredictionEntity.build({
+  function buildFakePrediction(isCalculated = false): PredictionEntity {
+    return PredictionEntity.build({
       id: 'pred-1' as Id,
       userEnrollmentId: enrollmentId,
-      matchId: matchId,
+      matchId,
       tournamentInstanceId: tiId,
       awayScore: 2,
       homeScore: 1,
       hasExactResult: false,
       earnedPoints: 0,
-      isCalculated: false,
-      userId: '' as Id,
+      isCalculated,
+      userId: 'u-1' as Id,
+      createdAt: new Date(),
     }).payload;
-    pred.earnedPoints = 4;
-    pred.calculateScore = jest
-      .fn()
-      .mockReturnValue({ total: 4, breakdown: [{ rule: 'ExactScoreRule', points: 1 }] });
-    pred.hasExactResult = true;
-    return pred;
+  }
+
+  function buildFinishedMatch(): MatchEntity {
+    return buildFakeMatch();
+  }
+
+  function buildScheduledMatch(): MatchEntity {
+    const match = buildFakeMatch();
+    match.status = MatchStatus.Scheduled;
+    return match;
   }
 
   function buildFakeEnrollment(id: Id): UserEnrollmentEntity {
     return UserEnrollmentEntity.build({
-      id: id,
+      id,
       userId: 'u-1' as Id,
       tournamentInstanceId: tiId,
       tournamentId: 't-1' as Id,
@@ -121,69 +150,120 @@ describe('CalculateMatchScoreUsecaseImpl', () => {
     }).payload;
   }
 
-  it('should calculate score for participants and reset streak for non-participants', async () => {
-    const match = buildFakeMatch(2, 1);
-    const prediction = buildFakePrediction();
-    const activeEnrollment = buildFakeEnrollment(enrollmentId);
-    const missingEnrollment = buildFakeEnrollment(missingEnrollmentId);
-
-    const matchContract = makeMockMatchContract(match);
-    const predictionContract = makeMockPredictionContract([prediction]);
-    const getUserEnrollment = makeMockGetUserEnrollmentUsecase(activeEnrollment);
-    const updateUserEnrollment = makeMockUpdateUserEnrollmentUsecase();
-    const getMissingEnrollments = makeMockGetEnrollmentsWithoutPredictionUsecase([
-      missingEnrollment,
-    ]);
+  function buildUsecase(overrides: {
+    match?: MatchEntity | null;
+    predictions?: PredictionEntity[];
+    enrollmentFound?: boolean;
+    missing?: UserEnrollmentEntity[];
+  }) {
+    const match = 'match' in overrides ? (overrides.match ?? null) : buildFakeMatch();
+    const matchContract = makeMatchContract(match);
+    const editPredictionDirectly = makeEditPredictionDirectly();
+    const getUserEnrollment = makeGetUserEnrollment(overrides.enrollmentFound ?? true);
+    const getPredictions = makeGetPredictions(overrides.predictions ?? []);
+    const updateUserEnrollment = makeUpdateUserEnrollment();
+    const getMissingEnrollments = makeGetMissingEnrollments(overrides.missing ?? []);
+    const logger = makeLogger();
 
     const usecase = new CalculateMatchScoreUsecaseImpl(
       matchContract,
-      predictionContract,
+      editPredictionDirectly,
+      getUserEnrollment,
+      getPredictions,
+      updateUserEnrollment,
+      getMissingEnrollments,
+      logger,
+    );
+
+    return {
+      usecase,
+      matchContract,
+      editPredictionDirectly,
       getUserEnrollment,
       updateUserEnrollment,
       getMissingEnrollments,
-    );
+      logger,
+    };
+  }
+
+  it('puntúa la predicción cuando el enrollment existe y marca el partido como calculado', async () => {
+    const { usecase, editPredictionDirectly, updateUserEnrollment, matchContract, logger } =
+      buildUsecase({
+        predictions: [buildFakePrediction()],
+        enrollmentFound: true,
+        missing: [buildFakeEnrollment(missingEnrollmentId)],
+      });
 
     const result = await usecase.call({ matchId, tournamentInstanceId: tiId });
 
-    expect(result.is(GottenMatchDomainEvent)).toBe(true);
-
-    // Validar actualización de quien sí predijo
-    expect(updateUserEnrollment.call).toHaveBeenCalledWith({
-      userEnrollmentId: enrollmentId,
-      points: prediction.earnedPoints,
-      isExact: true,
-    });
-
-    // Validar reinicio de racha de quien NO predijo
+    expect(result.is(CalculatedMatchDomainEvent)).toBe(true);
+    // Se puntuó la predicción pendiente del participante...
+    expect(editPredictionDirectly.call).toHaveBeenCalledTimes(1);
+    expect(updateUserEnrollment.call).toHaveBeenCalledWith(
+      expect.objectContaining({ userEnrollmentId: enrollmentId }),
+    );
+    // ...y se reinició la racha de quien NO predijo.
     expect(updateUserEnrollment.call).toHaveBeenCalledWith({
       userEnrollmentId: missingEnrollmentId,
       points: 0,
       isExact: false,
     });
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
-  it('should return MatchDoesNotExistDomainEvent if match is not found', async () => {
+  it('loguea un warn y omite la predicción cuando el enrollment no se encuentra (punto ciego)', async () => {
     const prediction = buildFakePrediction();
-    const activeEnrollment = buildFakeEnrollment(enrollmentId);
-    const missingEnrollment = buildFakeEnrollment(missingEnrollmentId);
+    const { usecase, editPredictionDirectly, logger } = buildUsecase({
+      predictions: [prediction],
+      enrollmentFound: false,
+    });
 
-    const matchContract = makeMockMatchContract(null);
-    const predictionContract = makeMockPredictionContract([prediction]);
-    const getUserEnrollment = makeMockGetUserEnrollmentUsecase(activeEnrollment);
-    const updateUserEnrollment = makeMockUpdateUserEnrollmentUsecase();
-    const getMissingEnrollments = makeMockGetEnrollmentsWithoutPredictionUsecase([
-      missingEnrollment,
-    ]);
-    const usecase = new CalculateMatchScoreUsecaseImpl(
-      matchContract,
-      predictionContract,
-      getUserEnrollment,
-      updateUserEnrollment,
-      getMissingEnrollments,
+    const result = await usecase.call({ matchId, tournamentInstanceId: tiId });
+
+    // El partido igual queda calculado, pero la predicción se omitió...
+    expect(result.is(CalculatedMatchDomainEvent)).toBe(true);
+    expect(editPredictionDirectly.call).not.toHaveBeenCalled();
+    // ...y ahora SÍ deja rastro estructurado.
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Prediction score skipped',
+      expect.objectContaining({
+        matchId,
+        predictionId: prediction.id,
+        userEnrollmentId: prediction.userEnrollmentId,
+        reason: 'enrollment_not_found',
+      }),
     );
+  });
+
+  it('devuelve MatchDoesNotExistDomainEvent si el partido no existe', async () => {
+    const { usecase } = buildUsecase({ match: null, predictions: [buildFakePrediction()] });
 
     const result = await usecase.call({ matchId, tournamentInstanceId: tiId });
 
     expect(result.is(MatchDoesNotExistDomainEvent)).toBe(true);
+  });
+
+  it('devuelve MatchHasNotFinishedDomainEvent si el partido no está finalizado', async () => {
+    const { usecase, editPredictionDirectly } = buildUsecase({
+      match: buildScheduledMatch(),
+      predictions: [buildFakePrediction()],
+    });
+
+    const result = await usecase.call({ matchId, tournamentInstanceId: tiId });
+
+    expect(result.is(MatchHasNotFinishedDomainEvent)).toBe(true);
+    expect(editPredictionDirectly.call).not.toHaveBeenCalled();
+  });
+
+  it('es idempotente: si todas las predicciones ya están calculadas devuelve MatchAlreadyCalculated y no re-puntúa', async () => {
+    const { usecase, editPredictionDirectly } = buildUsecase({
+      match: buildFinishedMatch(),
+      predictions: [buildFakePrediction(true)],
+    });
+
+    const result = await usecase.call({ matchId, tournamentInstanceId: tiId });
+
+    expect(result.is(MatchAlreadyCalculatedDomainEvent)).toBe(true);
+    expect(editPredictionDirectly.call).not.toHaveBeenCalled();
   });
 });

--- a/server/test/features/match/usecases/calculate-match-score.usecase-impl.spec.ts
+++ b/server/test/features/match/usecases/calculate-match-score.usecase-impl.spec.ts
@@ -95,6 +95,7 @@ describe('CalculateMatchScoreUsecaseImpl', () => {
       homeScore: 1,
       hasExactResult: false,
       earnedPoints: 0,
+      isCalculated: false,
       userId: '' as Id,
     }).payload;
     pred.earnedPoints = 4;

--- a/server/test/features/tournament/usecases/create-tournament.usecase-impl.spec.ts
+++ b/server/test/features/tournament/usecases/create-tournament.usecase-impl.spec.ts
@@ -1,4 +1,4 @@
-import { DomainEvent, EntityNotInstanciableDomainEvent } from '@skorify/domain/core';
+import { DomainEvent, EntityNotInstanciableDomainEvent, Id } from '@skorify/domain/core';
 import type { CreateTournamentParam } from '@skorify/domain/tournament';
 import {
   MatchType,
@@ -7,18 +7,64 @@ import {
   TournamentNotSavedDomainEvent,
   TournamentSavedDomainEvent,
 } from '@skorify/domain/tournament';
+import {
+  CreateTournamentInstanceUsecase,
+  TournamentInstanceEntity,
+  TournamentInstanceSavedDomainEvent,
+} from '@skorify/domain/tournament-instance';
+import { GetUserByIdUsecase, GottenUserDomainEvent, UserEntity } from '@skorify/domain/user';
 import { CreateTournamentUsecaseImpl } from '../../../../src/features/tournament/usecases/create-tournament.usecase-impl';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
+const ownerId = '99999999-9999-9999-9999-999999999999' as Id;
+
 const validParam: CreateTournamentParam = {
   name: 'World Cup 2026',
   matchType: MatchType.SingleMatchPerRound,
   startDate: new Date('2026-06-01'),
   endDate: new Date('2026-07-15'),
+  userId: ownerId,
 };
+
+function buildFakeOwner(): UserEntity {
+  return UserEntity.build({
+    id: ownerId,
+    name: 'Owner',
+    email: 'owner@test.com',
+    isActive: true,
+    notificationToken: '',
+    createdAt: new Date(),
+  }).payload as UserEntity;
+}
+
+function buildFakeInstance(): TournamentInstanceEntity {
+  return TournamentInstanceEntity.build({
+    id: 'cccccccc-cccc-cccc-cccc-cccccccccccc' as Id,
+    name: 'World Cup 2026-Global',
+    ownerId,
+    tournamentId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' as Id,
+    state: 'active',
+    inviteCode: 'ABCDEF',
+    createdAt: new Date(),
+  }).payload as TournamentInstanceEntity;
+}
+
+// Dependencias por defecto del "camino feliz": dueño existente y
+// creación de la instancia global sin choque de nombre.
+function makeDeps() {
+  const getUserByIdUsecase = {
+    call: jest.fn().mockResolvedValue(GottenUserDomainEvent(buildFakeOwner())),
+  } as unknown as GetUserByIdUsecase;
+
+  const createTournamentInstanceUsecase = {
+    call: jest.fn().mockResolvedValue(TournamentInstanceSavedDomainEvent(buildFakeInstance())),
+  } as unknown as CreateTournamentInstanceUsecase;
+
+  return { getUserByIdUsecase, createTournamentInstanceUsecase };
+}
 
 function buildFakeTournament(): DomainEvent {
   return TournamentEntity.build({
@@ -59,7 +105,12 @@ describe('CreateTournamentUsecaseImpl', () => {
       const contract = makeMockContract({
         save: jest.fn().mockResolvedValue(saved),
       });
-      const usecase = new CreateTournamentUsecaseImpl(contract);
+      const { getUserByIdUsecase, createTournamentInstanceUsecase } = makeDeps();
+      const usecase = new CreateTournamentUsecaseImpl(
+        contract,
+        createTournamentInstanceUsecase,
+        getUserByIdUsecase,
+      );
 
       const result = await usecase.call(validParam);
 
@@ -73,7 +124,12 @@ describe('CreateTournamentUsecaseImpl', () => {
       const contract = makeMockContract({
         save: jest.fn().mockResolvedValue(null),
       });
-      const usecase = new CreateTournamentUsecaseImpl(contract);
+      const { getUserByIdUsecase, createTournamentInstanceUsecase } = makeDeps();
+      const usecase = new CreateTournamentUsecaseImpl(
+        contract,
+        createTournamentInstanceUsecase,
+        getUserByIdUsecase,
+      );
 
       const result = await usecase.call(validParam);
 
@@ -85,7 +141,12 @@ describe('CreateTournamentUsecaseImpl', () => {
     it('returns EntityNotInstanciableDomainEvent and skips save', async () => {
       jest.spyOn(TournamentEntity, 'build').mockReturnValueOnce(EntityNotInstanciableDomainEvent());
       const contract = makeMockContract();
-      const usecase = new CreateTournamentUsecaseImpl(contract);
+      const { getUserByIdUsecase, createTournamentInstanceUsecase } = makeDeps();
+      const usecase = new CreateTournamentUsecaseImpl(
+        contract,
+        createTournamentInstanceUsecase,
+        getUserByIdUsecase,
+      );
 
       const result = await usecase.call(validParam);
 

--- a/server/test/features/user-enrollment/usecases/update-user-enrollment.usecase-impl.spec.ts
+++ b/server/test/features/user-enrollment/usecases/update-user-enrollment.usecase-impl.spec.ts
@@ -13,9 +13,7 @@ describe('UpdateUserEnrollmentUsecaseImpl', () => {
   function makeMockContract(enrollment: UserEnrollmentEntity | null): UserEnrollmentContract {
     return {
       getById: jest.fn().mockResolvedValue(enrollment),
-      modify: jest
-        .fn()
-        .mockImplementation((id: string, ent: UserEnrollmentEntity) => Promise.resolve(ent)),
+      modify: jest.fn().mockImplementation((ent: UserEnrollmentEntity) => Promise.resolve(ent)),
       save: jest.fn(),
       deleteById: jest.fn(),
       getAll: jest.fn(),
@@ -54,7 +52,7 @@ describe('UpdateUserEnrollmentUsecaseImpl', () => {
     expect(enrollment.currentScore).toBe(15);
     expect(enrollment.streak).toBe(3);
     expect(enrollment.maxStreak).toBe(3);
-    expect(contract.modify).toHaveBeenCalledWith(enrollmentId, enrollment);
+    expect(contract.modify).toHaveBeenCalledWith(enrollment);
   });
 
   it('should return NotGottenUserEnrollmentDomainEvent if enrollment does not exist', async () => {

--- a/server/test/features/user/usecases/register-user.usecase-impl.spec.ts
+++ b/server/test/features/user/usecases/register-user.usecase-impl.spec.ts
@@ -9,7 +9,7 @@ import {
   UserWithEmailAlreadyExistDomainEvent,
   type RegisterUserParam,
 } from '@skorify/domain/user';
-import { UserEntity } from '@skorify/domain/user/user.entity';
+import { UserEntity } from '@skorify/domain/user';
 import { RegisterUserUsecaseImpl } from '../../../../src/features/user/usecases/register-user.usecase-impl';
 
 describe('RegisterUserUsecaseImpl', () => {
@@ -18,9 +18,14 @@ describe('RegisterUserUsecaseImpl', () => {
   type MockCreateUser = Pick<CreateUserUsecase, 'call'>;
   type MockIdentityProvider = Pick<IdentityProviderContract, 'update'>;
 
+  // Cumple la política real de Cognito (>=8, mayúscula, número y símbolo),
+  // además del mínimo que valida el usecase (>=6).
+  const validPassword = 'Secret123!';
+
   const defaultParam: RegisterUserParam = {
     name: 'Bryan Arroyave',
     email: 'bryan@test.com',
+    password: validPassword,
   };
 
   function makeUser(): UserEntity {
@@ -121,7 +126,7 @@ describe('RegisterUserUsecaseImpl', () => {
 
     expect(res.eventName).toBe(UserRegisteredDomainEvent.eventName);
     expect(res.payload).toEqual(user);
-    expect(identityProviderContract.update).toHaveBeenCalledWith(user.id, {
+    expect(identityProviderContract.update).toHaveBeenCalledWith(user.id, validPassword, {
       name: user.name,
       email: user.email,
     });

--- a/server/test/prediction/make-prediction.usecase.spec.ts
+++ b/server/test/prediction/make-prediction.usecase.spec.ts
@@ -2,14 +2,18 @@ import { DomainEvent, type Id } from '@skorify/domain/core';
 import {
   GottenMatchDomainEvent,
   MatchDoesNotExistDomainEvent,
+  MatchEntity,
+  MatchStatus,
   type GetMatchByIdUsecase,
 } from '@skorify/domain/match';
-import { MatchEntity } from '@skorify/domain/match/match.entity';
-import { MatchStatus } from '@skorify/domain/match/match.state';
-import { PredictionCreatedDomainEvent, PredictionNotCreatedDomainEvent, type MakePredictionParam, type PredictionContract } from '@skorify/domain/prediction';
-import { PredictionEntity } from '@skorify/domain/prediction/prediction.entity';
-import { GottenUserDomainEvent, type GetUserByIdUsecase } from '@skorify/domain/user';
-import { UserEntity } from '@skorify/domain/user/user.entity';
+import {
+  PredictionCreatedDomainEvent,
+  PredictionEntity,
+  PredictionNotCreatedDomainEvent,
+  type MakePredictionParam,
+  type PredictionContract,
+} from '@skorify/domain/prediction';
+import { GottenUserDomainEvent, UserEntity, type GetUserByIdUsecase } from '@skorify/domain/user';
 import { MakePredictionUsecaseImpl } from '../../src/features/prediction/usecases/make-prediction.usecase-impl';
 import {
   UserEnrollmentEntity,

--- a/server/test/setup-crypto.ts
+++ b/server/test/setup-crypto.ts
@@ -1,0 +1,7 @@
+import { webcrypto } from 'node:crypto';
+
+// Los usecases usan `crypto.randomUUID()` (global en el runtime Node 22 del Lambda).
+// El entorno Node de jest no expone `crypto` global, así que lo inyectamos desde node:crypto.
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto as typeof globalThis.crypto;
+}

--- a/server/tsconfig.jest.json
+++ b/server/tsconfig.jest.json
@@ -1,4 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "jest"],
+    "isolatedModules": true
+  },
   "include": ["src", "test"]
 }


### PR DESCRIPTION
## Qué hace

- Agrega logging estructurado (Powertools) en todo el backend, en vez de `console.log`.
- Inyecta el Logger en `calculate-match-score` para registrar cuando una predicción se omite por no encontrar su enrollment.
- Habilita el soporte de Logger en el generador de single-lambda.
- Realinea y arregla las pruebas unitarias (6 suites, 33 pruebas) y reactiva el job de pruebas en el CI.
- Sube `@skorify/data` a la versión 1.4.5, lo que arregla la instalación en el CI.

## Verificación

- CI en verde.
- `tsc` sin errores y `jest` 33 de 33.

## Pendiente

- Métricas EMF (por ahora solo logs).