### PR TITLE
feat(openapi): genera openapi.yaml desde el código y lo valida en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 name: Build Server
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 "on":
   push:
     branches:
-      - feature/**
       - develop
 
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: Build Server
       - develop
 
   pull_request:
-    types: [closed, opened, edited]
+    types: [opened, synchronize, reopened, edited, closed]
     branches:
       - develop
       - main
@@ -52,6 +52,14 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm run mla
+
+      - name: Check OpenAPI in sync
+        working-directory: builders
+        run: pnpm run openapi:check
+
+      - name: Lint OpenAPI (Redocly)
+        working-directory: builders
+        run: pnpm run openapi:lint
 
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v3

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ shared/src/storage
 
 .idea
 **/.idea
+
+openapi-docs.html

--- a/builders/package.json
+++ b/builders/package.json
@@ -8,18 +8,24 @@
     "start": "pnpm ts-node src/index.ts",
     "sla": "pnpm ts-node src/index.ts single-lambda-aws",
     "mla": "pnpm ts-node src/index.ts module-lambda-aws",
+    "openapi": "pnpm ts-node src/openapi/generate-openapi.ts",
+    "openapi:check": "pnpm ts-node src/openapi/generate-openapi.ts --check",
+    "openapi:lint": "redocly lint ../openapi.yaml --config ../redocly.yaml",
+    "openapi:docs": "redocly build-docs ../openapi.yaml -o ../openapi-docs.html",
     "build": "tsc -p tsconfig.json"
   },
   "dependencies": {
     "@aws-lambda-powertools/logger": "^2.33.1"
   },
   "devDependencies": {
+    "@redocly/cli": "^2.31.6",
     "@scifamek-open-source/iraca": "9.2.0",
     "@skorify/domain": "github:aws-ug-manizales/Skorify_Domain#main",
     "@types/aws-lambda": "^8.10.161",
     "@types/node": "22.5.0",
     "ts-node": "10.9.2",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "yaml": "^2.9.0"
   },
   "keywords": [],
   "author": "",

--- a/builders/pnpm-lock.yaml
+++ b/builders/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^2.33.1
         version: 2.33.1
     devDependencies:
+      '@redocly/cli':
+        specifier: ^2.31.6
+        version: 2.31.6(@opentelemetry/api@1.9.1)(core-js@3.49.0)
       '@scifamek-open-source/iraca':
         specifier: 9.2.0
         version: 9.2.0
@@ -30,6 +33,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
 
 packages:
 
@@ -51,9 +57,38 @@ packages:
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@emotion/is-prop-valid@1.4.0':
+    resolution: {integrity: sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@exodus/schemasafe@1.3.0':
+    resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
+
+  '@faker-js/faker@7.6.0':
+    resolution: {integrity: sha512-XK6BTq1NDMo9Xqw/YkYyGjSsg44fbNwYRx7QK2CuoQgyy+f1rrTDHoExVM5PsyXCtfl2vs2vVJ0MN0yN6LppRw==}
+    engines: {node: '>=14.0.0', npm: '>=6.0.0'}
+
+  '@humanwhocodes/momoa@2.0.4':
+    resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
+    engines: {node: '>=10.10.0'}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -64,6 +99,147 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
+
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/context-async-hooks@2.6.1':
+    resolution: {integrity: sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.6.1':
+    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-http@0.214.0':
+    resolution: {integrity: sha512-kIN8nTBMgV2hXzV/a20BCFilPZdAIMYYJGSgfMMRm/Xa+07y5hRDS2Vm12A/z8Cdu3Sq++ZvJfElokX2rkgGgw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.214.0':
+    resolution: {integrity: sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.214.0':
+    resolution: {integrity: sha512-DSaYcuBRh6uozfsWN3R8HsN0yDhCuWP7tOFdkUOVaWD1KVJg8m4qiLUsg/tNhTLS9HUYUcwNpwL2eroLtsZZ/w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.6.1':
+    resolution: {integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.214.0':
+    resolution: {integrity: sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.6.1':
+    resolution: {integrity: sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.6.1':
+    resolution: {integrity: sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.6.1':
+    resolution: {integrity: sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
+  '@redocly/ajv@8.11.2':
+    resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
+
+  '@redocly/ajv@8.18.1':
+    resolution: {integrity: sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==}
+
+  '@redocly/cli-otel@0.3.1':
+    resolution: {integrity: sha512-TbC4bK2zLtU/O9I2pszHPP0rtJOvFhQmEwQ/FHxERPu71fgKG8POUDP2jSiGmsXE7NdGSHBKqnf+y9Acn2jq5g==}
+
+  '@redocly/cli@2.31.6':
+    resolution: {integrity: sha512-OQ7t/kDlewWIqYlo0jnNTUIkhmAuZx6P2OQmuZlaxghdRXbu/k+MevXSjR5uD2RGw4GLYsasGjUWPUonp6liTQ==}
+    engines: {node: '>=22.12.0 || >=20.19.0 <21.0.0', npm: '>=10'}
+    hasBin: true
+
+  '@redocly/config@0.22.0':
+    resolution: {integrity: sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==}
+
+  '@redocly/config@0.49.0':
+    resolution: {integrity: sha512-OI/rpEffX3fKUuy+OuBHPRspRI/S30b9aiqxfZLMpSWZzDncEGPxSEP1O2LrBVshnDX4hLjVjLvCZ4YT85+1rw==}
+
+  '@redocly/openapi-core@1.34.15':
+    resolution: {integrity: sha512-HAwCnNyKcs5XGQqms+9t7OdAPM/5TDstmhF+0i7tdCFato2QKuYIlyWETwkXd8c5zbltr1oB+6y9NTeQLr2d6Q==}
+    engines: {node: '>=18.17.0', npm: '>=9.5.0'}
+
+  '@redocly/openapi-core@2.31.6':
+    resolution: {integrity: sha512-h+zh6UQ4e5oRspUZUaNl1XRXwMf0ENHbGLKIDFAjhV6JACpqUrcBxkPKHY/uCXGdJSCzxVP3twCrnOWB0iMVuw==}
+    engines: {node: '>=22.12.0 || >=20.19.0 <21.0.0', npm: '>=10'}
+
+  '@redocly/respect-core@2.31.6':
+    resolution: {integrity: sha512-xLsbP+jRVTaYKMnx44nx4p9UqVGjZGqyq6bsYlQQWeLem83OrU4EPE7vKKIdWTuwtQkEQ1ousEuenW7lqeqFnA==}
+    engines: {node: '>=22.12.0 || >=20.19.0 <21.0.0', npm: '>=10'}
 
   '@scifamek-open-source/iraca@9.2.0':
     resolution: {integrity: sha512-YUyAT5+lfq6+/ARc1TlewTQsm2fR3iZZGNxjaodciX7nDpFJVyu85qtGQvfEaxKJoJT9+KxtMw+Vl4qmz6JHBA==}
@@ -87,8 +263,14 @@ packages:
   '@types/aws-lambda@8.10.161':
     resolution: {integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/node@22.5.0':
     resolution: {integrity: sha512-DkFrJOe+rfdHTqqMg0bSNlGlQ85hSoh2TPzZyhHsXnMtligRWpxUySiyw8FY14ITt24HVCiQPWxS3KO/QlGmWg==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
@@ -99,18 +281,515 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  better-ajv-errors@2.0.3:
+    resolution: {integrity: sha512-t1vxUP+vYKsaYi/BbKo2K98nEAZmfi4sjwvmRT8aOPDzPJeAtLurfoIDazVkLILxO4K+Sw4YrLYnBQ46l6pePg==}
+    engines: {node: '>= 18.20.6'}
+    peerDependencies:
+      ajv: 4.11.8 - 8
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@1.4.0:
+    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decko@1.2.0:
+    resolution: {integrity: sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ==}
 
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  es6-promise@3.3.1:
+    resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.8.0:
+    resolution: {integrity: sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==}
+    hasBin: true
+
+  foreach@2.0.6:
+    resolution: {integrity: sha512-k6GAGDyqLe9JaebCsFCoudPPWfihKu8pylYXRlqP1J7ms39iPoTtk2fviNglIeQEwdh0bQeKJ01ZPyuyQvKzwg==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  http2-client@1.3.5:
+    resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  js-levenshtein@1.1.6:
+    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
+    engines: {node: '>=0.10.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
+
+  json-pointer@0.6.2:
+    resolution: {integrity: sha512-vLWcKbOaXlO+jvRy4qNd+TI1QUPZzfJj1tpJ3vAXDych5XJf93ftpUKe5pKCrzyIIwgBJcOcCVRUfqQP25afBw==}
+
+  json-schema-to-ts@2.7.2:
+    resolution: {integrity: sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==}
+    engines: {node: '>=16'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  jsonpath-rfc9535@1.3.0:
+    resolution: {integrity: sha512-3jFHya7oZ45aDxIIdx+/zQARahHXxFSMWBkcBUldfXpLS9VCXDJyTKt35kQfEXLqh0K3Ixw/9xFnvcDStaxh7Q==}
+    engines: {node: '>=20'}
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  leven@3.1.0:
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
+    engines: {node: '>=6'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  mark.js@8.11.1:
+    resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
+  marked@4.3.0:
+    resolution: {integrity: sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==}
+    engines: {node: '>= 12'}
+    hasBin: true
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mobx-react-lite@4.1.1:
+    resolution: {integrity: sha512-iUxiMpsvNraCKXU+yPotsOncNNmyeS2B5DKL+TL6Tar/xm+wwNJAubJmtRSeAoYawdZqwv8Z/+5nPRHeQxTiXg==}
+    peerDependencies:
+      mobx: ^6.9.0
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
+  mobx-react@9.2.0:
+    resolution: {integrity: sha512-dkGWCx+S0/1mfiuFfHRH8D9cplmwhxOV5CkXMp38u6rQGG2Pv3FWYztS0M7ncR6TyPRQKaTG/pnitInoYE9Vrw==}
+    peerDependencies:
+      mobx: ^6.9.0
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
+  mobx@6.16.1:
+    resolution: {integrity: sha512-syNcDdX3KT+Jq3je6eGjBhuc24Z68td2VG0zNFqRswaE433D9SNH5VRy/xrGbJsUixfppLLccXhAW9JSf6n+SQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-fetch-h2@2.3.0:
+    resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==}
+    engines: {node: 4.x || >=6.0.0}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-readfiles@0.2.0:
+    resolution: {integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==}
+
+  oas-kit-common@1.0.8:
+    resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==}
+
+  oas-linter@3.2.2:
+    resolution: {integrity: sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==}
+
+  oas-resolver@2.5.6:
+    resolution: {integrity: sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==}
+    hasBin: true
+
+  oas-schema-walker@1.1.5:
+    resolution: {integrity: sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==}
+
+  oas-validator@5.0.8:
+    resolution: {integrity: sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  openapi-sampler@1.7.4:
+    resolution: {integrity: sha512-CKS/rd5ucPCuEDbJnjGDXZTsuGWcmv53aCmQx7soZlPEONUGN4af0/dY5+THRFZraSEjeA78nlfzdFswC/N5SA==}
+
+  outdent@0.8.0:
+    resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  perfect-scrollbar@1.5.6:
+    resolution: {integrity: sha512-rixgxw3SxyJbCaSpo1n35A/fwI1r2rdwMKOTCg/AcG+xOEyZcE8UHVjpZMFCVImzsFoCZeJTT+M/rdEIQYO2nw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+
+  polished@4.3.1:
+    resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
+    engines: {node: '>=10'}
+
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  protobufjs@7.6.2:
+    resolution: {integrity: sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==}
+    engines: {node: '>=12.0.0'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-tabs@6.1.1:
+    resolution: {integrity: sha512-CPiuKoMFf89B7QlbFfdBD9XmUWiE3qudQputMVZB8GQvPJZRX/gqjDaDWOPDwGinEfpJKEuBCkGt83Tt4efeyA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  redoc@2.5.3:
+    resolution: {integrity: sha512-bBbat+Sx6xKWdyoCGTtA0BWeTEW9Vs4VnEja7q7ZLOk4IM7cHQLrf+kDxWF6dKeKxT8kOBnoy/OsNXCeLttpyQ==}
+    engines: {node: '>=6.9', npm: '>=3.0.0'}
+    peerDependencies:
+      core-js: ^3.1.4
+      mobx: ^6.0.4
+      react: ^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.4 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      styled-components: ^4.1.1 || ^5.1.1 || ^6.0.5
+
+  reftools@1.1.9:
+    resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.8.3:
+    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  should-equal@2.0.0:
+    resolution: {integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==}
+
+  should-format@3.0.3:
+    resolution: {integrity: sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==}
+
+  should-type-adaptors@1.1.0:
+    resolution: {integrity: sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==}
+
+  should-type@1.4.0:
+    resolution: {integrity: sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==}
+
+  should-util@1.0.1:
+    resolution: {integrity: sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==}
+
+  should@13.2.3:
+    resolution: {integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==}
+
+  simple-websocket@9.1.0:
+    resolution: {integrity: sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ==}
+
+  slugify@1.4.7:
+    resolution: {integrity: sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg==}
+    engines: {node: '>=8.0.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  stickyfill@1.1.1:
+    resolution: {integrity: sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
+  styled-components@6.4.2:
+    resolution: {integrity: sha512-xZBhBJsMtGqb+aKcwKgaT+BtuFums9VynX2JRvXJGTx5UfZzN12rk5r4nVdhXYvRw+hE7yiYxVrOqJZaK2+Txg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      css-to-react-native: '>= 3.2.0'
+      react: '>= 16.8.0'
+      react-dom: '>= 16.8.0'
+      react-native: '>= 0.68.0'
+    peerDependenciesMeta:
+      css-to-react-native:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
+  stylis@4.3.6:
+    resolution: {integrity: sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  swagger2openapi@7.0.8:
+    resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
+    hasBin: true
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  ts-algebra@1.2.2:
+    resolution: {integrity: sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==}
 
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
@@ -131,11 +810,95 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+
+  ulid@2.4.0:
+    resolution: {integrity: sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==}
+    hasBin: true
+
+  ulid@3.0.2:
+    resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
+    hasBin: true
+
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  undici@6.24.0:
+    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
+    engines: {node: '>=18.17'}
+
+  uri-js-replace@1.0.1:
+    resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
+
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yaml-ast-parser@0.0.43:
+    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
+
+  yaml@1.10.3:
+    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
+    engines: {node: '>= 6'}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs@17.0.1:
+    resolution: {integrity: sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==}
+    engines: {node: '>=12'}
 
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
@@ -154,9 +917,31 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/runtime@7.29.7': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@emotion/is-prop-valid@1.4.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+
+  '@emotion/memoize@0.9.0': {}
+
+  '@exodus/schemasafe@1.3.0': {}
+
+  '@faker-js/faker@7.6.0': {}
+
+  '@humanwhocodes/momoa@2.0.4': {}
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -166,6 +951,215 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@noble/hashes@1.8.0': {}
+
+  '@nodable/entities@2.1.1': {}
+
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/context-async-hooks@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.214.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+      protobufjs: 7.6.2
+
+  '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-node@2.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.6.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
+  '@redocly/ajv@8.11.2':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js-replace: 1.0.1
+
+  '@redocly/ajv@8.18.1':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  '@redocly/cli-otel@0.3.1':
+    dependencies:
+      ulid: 2.4.0
+
+  '@redocly/cli@2.31.6(@opentelemetry/api@1.9.1)(core-js@3.49.0)':
+    dependencies:
+      '@opentelemetry/exporter-trace-otlp-http': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@redocly/cli-otel': 0.3.1
+      '@redocly/openapi-core': 2.31.6
+      '@redocly/respect-core': 2.31.6
+      ajv: '@redocly/ajv@8.18.1'
+      ajv-formats: 3.0.1(@redocly/ajv@8.18.1)
+      colorette: 1.4.0
+      cookie: 0.7.2
+      dotenv: 16.4.7
+      glob: 13.0.6
+      handlebars: 4.7.9
+      https-proxy-agent: 7.0.6
+      mobx: 6.16.1
+      picomatch: 4.0.4
+      pluralize: 8.0.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      redoc: 2.5.3(core-js@3.49.0)(mobx@6.16.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      semver: 7.8.3
+      set-cookie-parser: 2.7.2
+      simple-websocket: 9.1.0
+      styled-components: 6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      ulid: 3.0.2
+      undici: 6.24.0
+      yargs: 17.0.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - bufferutil
+      - core-js
+      - css-to-react-native
+      - encoding
+      - react-native
+      - supports-color
+      - utf-8-validate
+
+  '@redocly/config@0.22.0': {}
+
+  '@redocly/config@0.49.0':
+    dependencies:
+      json-schema-to-ts: 2.7.2
+
+  '@redocly/openapi-core@1.34.15':
+    dependencies:
+      '@redocly/ajv': 8.11.2
+      '@redocly/config': 0.22.0
+      colorette: 1.4.0
+      https-proxy-agent: 7.0.6
+      js-levenshtein: 1.1.6
+      js-yaml: 4.1.1
+      minimatch: 5.1.9
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+    transitivePeerDependencies:
+      - supports-color
+
+  '@redocly/openapi-core@2.31.6':
+    dependencies:
+      '@redocly/ajv': 8.18.1
+      '@redocly/config': 0.49.0
+      ajv: '@redocly/ajv@8.18.1'
+      ajv-formats: 3.0.1(@redocly/ajv@8.18.1)
+      colorette: 1.4.0
+      js-levenshtein: 1.1.6
+      js-yaml: 4.2.0
+      picomatch: 4.0.4
+      pluralize: 8.0.0
+      yaml-ast-parser: 0.0.43
+
+  '@redocly/respect-core@2.31.6':
+    dependencies:
+      '@faker-js/faker': 7.6.0
+      '@noble/hashes': 1.8.0
+      '@redocly/ajv': 8.18.1
+      '@redocly/openapi-core': 2.31.6
+      ajv: '@redocly/ajv@8.18.1'
+      better-ajv-errors: 2.0.3(@redocly/ajv@8.18.1)
+      colorette: 2.0.20
+      json-pointer: 0.6.2
+      jsonpath-rfc9535: 1.3.0
+      openapi-sampler: 1.7.4
+      outdent: 0.8.0
+      picomatch: 4.0.4
 
   '@scifamek-open-source/iraca@9.2.0': {}
 
@@ -181,9 +1175,14 @@ snapshots:
 
   '@types/aws-lambda@8.10.161': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/node@22.5.0':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   acorn-walk@8.3.5:
     dependencies:
@@ -191,13 +1190,498 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(@redocly/ajv@8.18.1):
+    optionalDependencies:
+      ajv: '@redocly/ajv@8.18.1'
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   arg@4.1.3: {}
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  better-ajv-errors@2.0.3(@redocly/ajv@8.18.1):
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@humanwhocodes/momoa': 2.0.4
+      ajv: '@redocly/ajv@8.18.1'
+      chalk: 4.1.2
+      jsonpointer: 5.0.1
+      leven: 3.1.0
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  call-me-maybe@1.0.2: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  classnames@2.5.1: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  colorette@1.4.0: {}
+
+  colorette@2.0.20: {}
+
+  cookie@0.7.2: {}
+
+  core-js@3.49.0: {}
 
   create-require@1.1.1: {}
 
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decko@1.2.0: {}
+
   diff@4.0.4: {}
 
+  dompurify@3.4.8:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  dotenv@16.4.7: {}
+
+  emoji-regex@8.0.0: {}
+
+  es6-promise@3.3.1: {}
+
+  escalade@3.2.0: {}
+
+  eventemitter3@5.0.4: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.1.2: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.8.0:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
+      xml-naming: 0.1.0
+
+  foreach@2.0.6: {}
+
+  get-caller-file@2.0.5: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  has-flag@4.0.0: {}
+
+  http2-client@1.3.5: {}
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  inherits@2.0.4: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  js-levenshtein@1.1.6: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-pointer@0.6.2:
+    dependencies:
+      foreach: 2.0.6
+
+  json-schema-to-ts@2.7.2:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/json-schema': 7.0.15
+      ts-algebra: 1.2.2
+
+  json-schema-traverse@1.0.0: {}
+
+  jsonpath-rfc9535@1.3.0: {}
+
+  jsonpointer@5.0.1: {}
+
+  leven@3.1.0: {}
+
+  long@5.3.2: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@11.5.1: {}
+
+  lunr@2.3.9: {}
+
   make-error@1.3.6: {}
+
+  mark.js@8.11.1: {}
+
+  marked@4.3.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
+
+  mobx-react-lite@4.1.1(mobx@6.16.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      mobx: 6.16.1
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
+  mobx-react@9.2.0(mobx@6.16.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      mobx: 6.16.1
+      mobx-react-lite: 4.1.1(mobx@6.16.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
+  mobx@6.16.1: {}
+
+  ms@2.1.3: {}
+
+  neo-async@2.6.2: {}
+
+  node-fetch-h2@2.3.0:
+    dependencies:
+      http2-client: 1.3.5
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-readfiles@0.2.0:
+    dependencies:
+      es6-promise: 3.3.1
+
+  oas-kit-common@1.0.8:
+    dependencies:
+      fast-safe-stringify: 2.1.1
+
+  oas-linter@3.2.2:
+    dependencies:
+      '@exodus/schemasafe': 1.3.0
+      should: 13.2.3
+      yaml: 1.10.3
+
+  oas-resolver@2.5.6:
+    dependencies:
+      node-fetch-h2: 2.3.0
+      oas-kit-common: 1.0.8
+      reftools: 1.1.9
+      yaml: 1.10.3
+      yargs: 17.0.1
+
+  oas-schema-walker@1.1.5: {}
+
+  oas-validator@5.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      oas-kit-common: 1.0.8
+      oas-linter: 3.2.2
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      reftools: 1.1.9
+      should: 13.2.3
+      yaml: 1.10.3
+
+  object-assign@4.1.1: {}
+
+  openapi-sampler@1.7.4:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      fast-xml-parser: 5.8.0
+      json-pointer: 0.6.2
+
+  outdent@0.8.0: {}
+
+  path-browserify@1.0.1: {}
+
+  path-expression-matcher@1.5.0: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
+  perfect-scrollbar@1.5.6: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pluralize@8.0.0: {}
+
+  polished@4.3.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+
+  prismjs@1.30.0: {}
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
+  protobufjs@7.6.2:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.5.0
+      long: 5.3.2
+
+  queue-microtask@1.2.3: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-is@16.13.1: {}
+
+  react-tabs@6.1.1(react@19.2.7):
+    dependencies:
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+
+  react@19.2.7: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  redoc@2.5.3(core-js@3.49.0)(mobx@6.16.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+    dependencies:
+      '@redocly/openapi-core': 1.34.15
+      classnames: 2.5.1
+      core-js: 3.49.0
+      decko: 1.2.0
+      dompurify: 3.4.8
+      eventemitter3: 5.0.4
+      json-pointer: 0.6.2
+      lunr: 2.3.9
+      mark.js: 8.11.1
+      marked: 4.3.0
+      mobx: 6.16.1
+      mobx-react: 9.2.0(mobx@6.16.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      openapi-sampler: 1.7.4
+      path-browserify: 1.0.1
+      perfect-scrollbar: 1.5.6
+      polished: 4.3.1
+      prismjs: 1.30.0
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-tabs: 6.1.1(react@19.2.7)
+      slugify: 1.4.7
+      stickyfill: 1.1.1
+      styled-components: 6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      swagger2openapi: 7.0.8
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - encoding
+      - react-native
+      - supports-color
+
+  reftools@1.1.9: {}
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  scheduler@0.27.0: {}
+
+  semver@7.8.3: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  should-equal@2.0.0:
+    dependencies:
+      should-type: 1.4.0
+
+  should-format@3.0.3:
+    dependencies:
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+
+  should-type-adaptors@1.1.0:
+    dependencies:
+      should-type: 1.4.0
+      should-util: 1.0.1
+
+  should-type@1.4.0: {}
+
+  should-util@1.0.1: {}
+
+  should@13.2.3:
+    dependencies:
+      should-equal: 2.0.0
+      should-format: 3.0.3
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+      should-util: 1.0.1
+
+  simple-websocket@9.1.0:
+    dependencies:
+      debug: 4.4.3
+      queue-microtask: 1.2.3
+      randombytes: 2.1.0
+      readable-stream: 3.6.2
+      ws: 7.5.11
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  slugify@1.4.7: {}
+
+  source-map@0.6.1: {}
+
+  stickyfill@1.1.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strnum@2.3.0: {}
+
+  styled-components@6.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@emotion/is-prop-valid': 1.4.0
+      csstype: 3.2.3
+      react: 19.2.7
+      stylis: 4.3.6
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
+  stylis@4.3.6: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  swagger2openapi@7.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      node-fetch: 2.7.0
+      node-fetch-h2: 2.3.0
+      node-readfiles: 0.2.0
+      oas-kit-common: 1.0.8
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      oas-validator: 5.0.8
+      reftools: 1.1.9
+      yaml: 1.10.3
+      yargs: 17.0.1
+    transitivePeerDependencies:
+      - encoding
+
+  tr46@0.0.3: {}
+
+  ts-algebra@1.2.2: {}
 
   ts-node@10.9.2(@types/node@22.5.0)(typescript@5.8.3):
     dependencies:
@@ -219,8 +1703,66 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
+  ulid@2.4.0: {}
+
+  ulid@3.0.2: {}
+
   undici-types@6.19.8: {}
 
+  undici@6.24.0: {}
+
+  uri-js-replace@1.0.1: {}
+
+  url-template@2.0.8: {}
+
+  use-sync-external-store@1.6.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  util-deprecate@1.0.2: {}
+
   v8-compile-cache-lib@3.0.1: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  wordwrap@1.0.0: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  ws@7.5.11: {}
+
+  xml-naming@0.1.0: {}
+
+  y18n@5.0.8: {}
+
+  yaml-ast-parser@0.0.43: {}
+
+  yaml@1.10.3: {}
+
+  yaml@2.9.0: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs@17.0.1:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yn@3.1.1: {}

--- a/builders/src/openapi/generate-openapi.ts
+++ b/builders/src/openapi/generate-openapi.ts
@@ -1,0 +1,460 @@
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import * as ts from 'typescript';
+import { stringify } from 'yaml';
+
+const ROOT = join(__dirname, '..', '..', '..');
+const TEMPLATE_PATH = join(ROOT, 'builders', 'dist', 'template.yaml');
+const OUTPUT_PATH = join(ROOT, 'openapi.yaml');
+const FEATURES = join(ROOT, 'server', 'src', 'features');
+
+const DOMAIN_DIST =
+  [
+    join(ROOT, 'builders', 'node_modules', '@skorify', 'domain', 'dist'),
+    join(ROOT, 'server', 'node_modules', '@skorify', 'domain', 'dist'),
+    join(ROOT, 'node_modules', '@skorify', 'domain', 'dist'),
+  ].find(existsSync) ?? '';
+
+const BODY_METHODS = new Set(['put', 'post', 'patch']);
+
+const capitalize = (w: string) => w.charAt(0).toUpperCase() + w.slice(1);
+const toCamelCase = (k: string) => k.split('-').map((p, i) => (i ? capitalize(p) : p)).join('');
+const toPascalCase = (k: string) => k.split('-').map(capitalize).join('');
+const toTitleCase = (k: string) => k.split('-').map(capitalize).join(' ');
+const toSentence = (k: string) => capitalize(k.split('-').join(' '));
+
+function walkFiles(dir: string, filter: (f: string) => boolean): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walkFiles(full, filter));
+    else if (filter(full)) out.push(full);
+  }
+  return out;
+}
+
+function parseFile(file: string): ts.SourceFile {
+  return ts.createSourceFile(file, readFileSync(file, 'utf-8'), ts.ScriptTarget.Latest, true);
+}
+
+interface Member { name: string; type: ts.TypeNode; optional: boolean; }
+const interfaces = new Map<string, Member[]>();
+const classes = new Map<string, { members: Member[]; base?: string }>();
+const aliases = new Map<string, ts.TypeNode>();
+const domainEvents = new Map<string, ts.TypeNode | null>();
+
+function memberFrom(m: ts.PropertySignature | ts.PropertyDeclaration): Member | null {
+  if (!m.type || !m.name) return null;
+  const name = m.name.getText();
+  if (name.startsWith('_')) return null;
+  if (m.modifiers?.some((x) => x.kind === ts.SyntaxKind.PrivateKeyword)) return null;
+  return { name, type: m.type, optional: !!m.questionToken };
+}
+
+function payloadTypeOf(typeNode: ts.TypeNode | undefined): ts.TypeNode | null | undefined {
+  if (!typeNode) return undefined;
+  let name = '';
+  let args: ts.NodeArray<ts.TypeNode> | undefined;
+  if (ts.isImportTypeNode(typeNode)) {
+    name = typeNode.qualifier?.getText() ?? '';
+    args = typeNode.typeArguments;
+  } else if (ts.isTypeReferenceNode(typeNode)) {
+    name = typeNode.typeName.getText();
+    args = typeNode.typeArguments;
+  } else {
+    return undefined;
+  }
+  if (name.endsWith('DomainEventKindWithPayload') || name === 'DomainEventKindWithPayload') {
+    return args?.[0] ?? null;
+  }
+  if (name.endsWith('DomainEventKind') || name === 'DomainEventKind') return null;
+  return undefined;
+}
+
+function indexDomain(): void {
+  if (!DOMAIN_DIST) return;
+  for (const file of walkFiles(DOMAIN_DIST, (f) => f.endsWith('.d.ts'))) {
+    parseFile(file).forEachChild((node) => {
+      if (ts.isInterfaceDeclaration(node)) {
+        interfaces.set(node.name.text, node.members.map((m) =>
+          ts.isPropertySignature(m) ? memberFrom(m) : null).filter(Boolean) as Member[]);
+      } else if (ts.isClassDeclaration(node) && node.name) {
+        const members = node.members
+          .map((m) => (ts.isPropertyDeclaration(m) ? memberFrom(m) : null))
+          .filter(Boolean) as Member[];
+        const base = node.heritageClauses
+          ?.find((h) => h.token === ts.SyntaxKind.ExtendsKeyword)
+          ?.types[0]?.expression.getText();
+        classes.set(node.name.text, { members, base });
+      } else if (ts.isTypeAliasDeclaration(node)) {
+        aliases.set(node.name.text, node.type);
+      } else if (ts.isVariableStatement(node)) {
+        for (const d of node.declarationList.declarations) {
+          const evName = d.name.getText();
+          if (!/DomainEvent$/.test(evName)) continue;
+          const payload = payloadTypeOf(d.type);
+          if (payload !== undefined) domainEvents.set(evName, payload);
+        }
+      }
+    });
+  }
+}
+
+function typeToSchema(type: ts.TypeNode, depth = 0): any {
+  if (depth > 8) return {};
+  switch (type.kind) {
+    case ts.SyntaxKind.StringKeyword: return { type: 'string' };
+    case ts.SyntaxKind.NumberKeyword: return { type: 'number' };
+    case ts.SyntaxKind.BooleanKeyword: return { type: 'boolean' };
+    case ts.SyntaxKind.AnyKeyword:
+    case ts.SyntaxKind.UnknownKeyword:
+    case ts.SyntaxKind.ObjectKeyword: return {};
+  }
+  if (ts.isParenthesizedTypeNode(type)) return typeToSchema(type.type, depth + 1);
+  if (ts.isTemplateLiteralTypeNode(type)) return { type: 'string' };
+  if (ts.isLiteralTypeNode(type)) {
+    if (ts.isStringLiteral(type.literal)) return { type: 'string' };
+    if (ts.isNumericLiteral(type.literal)) return { type: 'number' };
+    return {};
+  }
+  if (ts.isArrayTypeNode(type)) return { type: 'array', items: typeToSchema(type.elementType, depth + 1) };
+  if (ts.isTypeReferenceNode(type)) {
+    const name = type.typeName.getText();
+    if (name === 'Date') return { type: 'string', format: 'date-time' };
+    if ((name === 'Array' || name === 'Promise') && type.typeArguments?.[0]) {
+      const inner = typeToSchema(type.typeArguments[0], depth + 1);
+      return name === 'Array' ? { type: 'array', items: inner } : inner;
+    }
+    if (aliases.has(name)) return typeToSchema(aliases.get(name)!, depth + 1);
+    if (interfaces.has(name)) return objectSchema(interfaces.get(name)!, depth + 1);
+    if (classes.has(name)) return classSchema(name, depth + 1);
+    return { type: 'string' };
+  }
+  if (ts.isUnionTypeNode(type)) {
+    const real = type.types.filter(
+      (t) => t.kind !== ts.SyntaxKind.UndefinedKeyword && t.kind !== ts.SyntaxKind.NullKeyword,
+    );
+    const lits = real.filter(ts.isLiteralTypeNode);
+    if (lits.length && lits.length === real.length && lits.every((l) => ts.isStringLiteral(l.literal))) {
+      return { type: 'string', enum: lits.map((l) => l.literal.getText().replace(/['"]/g, '')) };
+    }
+    return typeToSchema(real[0] ?? type.types[0], depth + 1);
+  }
+  if (ts.isTypeLiteralNode(type)) {
+    const members = type.members
+      .map((m) => (ts.isPropertySignature(m) ? memberFrom(m) : null))
+      .filter(Boolean) as Member[];
+    return objectSchema(members, depth + 1);
+  }
+  return {};
+}
+
+function objectSchema(members: Member[], depth = 0): any {
+  const properties: Record<string, any> = {};
+  const required: string[] = [];
+  for (const m of members) {
+    properties[m.name] = typeToSchema(m.type, depth + 1);
+    if (!m.optional) required.push(m.name);
+  }
+  return { type: 'object', properties, ...(required.length ? { required } : {}) };
+}
+
+function classSchema(name: string, depth = 0): any {
+  if (depth > 8) return { type: 'object' };
+  const cls = classes.get(name);
+  if (!cls) return { type: 'object' };
+  return objectSchema(classSchemaMembers(name, depth), depth);
+}
+
+function classSchemaMembers(name: string, depth = 0): Member[] {
+  if (depth > 8) return [];
+  const cls = classes.get(name);
+  if (!cls) return [];
+  const base = cls.base && classes.has(cls.base) ? classSchemaMembers(cls.base, depth + 1) : [];
+  return [...base, ...cls.members];
+}
+
+function eventDataSchema(eventName: string): any {
+  const payload = domainEvents.get(eventName);
+  return payload ? typeToSchema(payload) : {};
+}
+
+interface Propagation {
+  usecase: string;
+  exclude: string[];
+  includeOnly: string[];
+}
+interface UsecaseInfo {
+  directEvents: Set<string>;
+  propagations: Propagation[];
+  entityBuild: boolean;
+}
+const usecaseIndex = new Map<string, UsecaseInfo>();
+
+function guardForReturn(rs: ts.ReturnStatement, ident: string): { exclude: string[]; includeOnly: string[] } {
+  let p: ts.Node | undefined = rs.parent;
+  while (p && !ts.isIfStatement(p)) p = p.parent;
+  const exclude: string[] = [];
+  const includeOnly: string[] = [];
+  if (!p || !ts.isIfStatement(p)) return { exclude, includeOnly };
+  const scan = (n: ts.Node) => {
+    if (
+      ts.isCallExpression(n) &&
+      ts.isPropertyAccessExpression(n.expression) &&
+      n.expression.expression.getText() === ident &&
+      n.arguments[0] &&
+      ts.isIdentifier(n.arguments[0])
+    ) {
+      const fn = n.expression.name.text;
+      if (fn === 'isNot') exclude.push(n.arguments[0].text);
+      else if (fn === 'is') includeOnly.push(n.arguments[0].text);
+    }
+    n.forEachChild(scan);
+  };
+  scan(p.expression);
+  return { exclude, includeOnly };
+}
+
+const unwrap = (e: ts.Expression): ts.Expression =>
+  ts.isAwaitExpression(e) || ts.isParenthesizedExpression(e) ? unwrap(e.expression) : e;
+
+function calledUsecaseProp(e: ts.Expression): string | null {
+  if (!ts.isCallExpression(e) || !ts.isPropertyAccessExpression(e.expression)) return null;
+  if (e.expression.name.text !== 'call') return null;
+  const obj = e.expression.expression;
+  if (ts.isPropertyAccessExpression(obj) && obj.expression.kind === ts.SyntaxKind.ThisKeyword) {
+    return obj.name.text;
+  }
+  return null;
+}
+
+const isEntityBuild = (e: ts.Expression): boolean =>
+  ts.isCallExpression(e) && ts.isPropertyAccessExpression(e.expression) && e.expression.name.text === 'build';
+
+const isPromiseAll = (e: ts.Expression): boolean =>
+  ts.isCallExpression(e) &&
+  ts.isPropertyAccessExpression(e.expression) &&
+  e.expression.name.text === 'all' &&
+  e.expression.expression.getText() === 'Promise';
+
+function analyzeImpl(cls: ts.ClassDeclaration): UsecaseInfo {
+  const deps = new Map<string, string>();
+  const ctor = cls.members.find(ts.isConstructorDeclaration);
+  ctor?.parameters.forEach((p) => {
+    if (p.modifiers?.length && p.type && ts.isIdentifier(p.name)) deps.set(p.name.text, p.type.getText());
+  });
+
+  const origin = new Map<string, { usecase?: string; build?: boolean }>();
+  const info: UsecaseInfo = { directEvents: new Set(), propagations: [], entityBuild: false };
+
+  const visit = (n: ts.Node) => {
+    if (ts.isVariableDeclaration(n) && n.initializer) {
+      const init = unwrap(n.initializer);
+      if (ts.isIdentifier(n.name)) {
+        const prop = calledUsecaseProp(init);
+        if (prop && deps.has(prop)) origin.set(n.name.text, { usecase: deps.get(prop) });
+        else if (isEntityBuild(init)) origin.set(n.name.text, { build: true });
+      } else if (ts.isArrayBindingPattern(n.name) && isPromiseAll(init)) {
+        const arr = (init as ts.CallExpression).arguments[0];
+        if (arr && ts.isArrayLiteralExpression(arr)) {
+          n.name.elements.forEach((el, i) => {
+            if (ts.isBindingElement(el) && ts.isIdentifier(el.name)) {
+              const callExpr = arr.elements[i] && unwrap(arr.elements[i] as ts.Expression);
+              const prop = callExpr && calledUsecaseProp(callExpr);
+              if (prop && deps.has(prop)) origin.set(el.name.text, { usecase: deps.get(prop) });
+            }
+          });
+        }
+      }
+    }
+    if (ts.isReturnStatement(n) && n.expression) {
+      const expr = unwrap(n.expression);
+      if (ts.isCallExpression(expr) && ts.isIdentifier(expr.expression) && /DomainEvent$/.test(expr.expression.text)) {
+        info.directEvents.add(expr.expression.text);
+      } else if (ts.isIdentifier(expr)) {
+        const o = origin.get(expr.text);
+        if (o?.usecase) info.propagations.push({ usecase: o.usecase, ...guardForReturn(n, expr.text) });
+        else if (o?.build) info.entityBuild = true;
+      }
+    }
+    n.forEachChild(visit);
+  };
+  visit(cls);
+  return info;
+}
+
+function indexImpls(): void {
+  for (const file of walkFiles(FEATURES, (f) => f.endsWith('.usecase-impl.ts'))) {
+    parseFile(file).forEachChild((node) => {
+      if (ts.isClassDeclaration(node) && node.name && /UsecaseImpl$/.test(node.name.text)) {
+        usecaseIndex.set(node.name.text.replace(/Impl$/, ''), analyzeImpl(node));
+      }
+    });
+  }
+}
+
+function resolveEvents(usecaseName: string, seen = new Set<string>()): Set<string> {
+  if (seen.has(usecaseName)) return new Set();
+  seen.add(usecaseName);
+  const info = usecaseIndex.get(usecaseName);
+  if (!info) return new Set();
+  const events = new Set(info.directEvents);
+  if (info.entityBuild) events.add('EntityNotInstanciableDomainEvent');
+  for (const prop of info.propagations) {
+    if (prop.includeOnly.length) {
+      prop.includeOnly.forEach((e) => events.add(e));
+    } else {
+      resolveEvents(prop.usecase, new Set(seen)).forEach((e) => {
+        if (!prop.exclude.includes(e)) events.add(e);
+      });
+    }
+  }
+  return events;
+}
+
+interface Route { usecaseName: string; module: string; path: string; method: string; }
+
+function parseRoutes(text: string): Route[] {
+  const re = /(\w+):\s*\n\s*Type:\s*Api\s*\n\s*Properties:\s*\n\s*Path:\s*(\S+)\s*\n\s*Method:\s*(\S+)/g;
+  const routes: Route[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    routes.push({ usecaseName: m[1], module: m[2].split('/').filter(Boolean)[0], path: m[2], method: m[3].toLowerCase() });
+  }
+  routes.sort((a, b) => a.path.localeCompare(b.path) || a.method.localeCompare(b.method));
+  return routes;
+}
+
+function buildOperation(route: Route): any {
+  const usecase = route.path.split('/').filter(Boolean).pop()!;
+  const baseName = route.usecaseName.replace(/Usecase$/, '');
+  const op: any = { tags: [toTitleCase(route.module)], summary: toSentence(usecase), operationId: toCamelCase(usecase) };
+
+  const paramName = `${baseName}Param`;
+  const paramSchema = interfaces.has(paramName) ? objectSchema(interfaces.get(paramName)!) : null;
+  if (paramSchema?.properties && Object.keys(paramSchema.properties).length) {
+    if (BODY_METHODS.has(route.method)) {
+      op.requestBody = { required: true, content: { 'application/json': { schema: paramSchema } } };
+    } else {
+      op.parameters = Object.entries(paramSchema.properties).map(([name, schema]) => ({
+        name, in: 'query', required: (paramSchema.required ?? []).includes(name), schema,
+      }));
+    }
+  }
+
+  const pascal = toPascalCase(route.module);
+  const events = [...resolveEvents(route.usecaseName)].sort();
+  const branches = events.map((ev) => ({
+    title: ev,
+    type: 'object',
+    properties: {
+      meta: { type: 'object', properties: { code: { type: 'string', enum: [`${pascal}:${ev}`] } }, required: ['code'] },
+      data: eventDataSchema(ev),
+    },
+    required: ['meta'],
+  }));
+  const schema = branches.length
+    ? { oneOf: branches }
+    : { type: 'object', properties: { meta: { type: 'object' }, data: {} } };
+
+  op.responses = {
+    '200': {
+      description: 'Domain Event. El tipo va en meta.code y el payload en data.',
+      content: { 'application/json': { schema } },
+    },
+    '500': { description: 'Error no controlado' },
+  };
+  return op;
+}
+
+function readVersion(): string {
+  try {
+    return JSON.parse(readFileSync(join(ROOT, 'server', 'package.json'), 'utf-8')).version ?? '1.0.0';
+  } catch {
+    return '1.0.0';
+  }
+}
+
+function buildOpenApi(routes: Route[]): string {
+  const modules = [...new Set(routes.map((r) => r.module))].sort();
+  const paths: Record<string, any> = {};
+  for (const route of routes) (paths[route.path] ??= {})[route.method] = buildOperation(route);
+
+  const doc = {
+    openapi: '3.2.0',
+    info: {
+      title: 'Skorify Backend API',
+      description:
+        `API RESTful del backend de Skorify. Documento generado automaticamente desde el codigo ` +
+        `(${routes.length} endpoints). Todas las respuestas son Domain Events: el handler responde ` +
+        `HTTP 200 con { data, meta.code }, donde meta.code identifica el evento (exito o error de negocio).`,
+      version: readVersion(),
+    },
+    servers: [
+      { url: 'https://api.skorify.cloud-manizales.com', description: 'Entorno PROD' },
+      { url: 'https://api.skorify-dev.cloud-manizales.com', description: 'Entorno DEV' },
+      { url: 'http://localhost:9898', description: 'Servidor local' },
+    ],
+    tags: modules.map((module) => ({
+      name: toTitleCase(module),
+      description: `Endpoints de ${toTitleCase(module)} (${routes.filter((r) => r.module === module).length})`,
+    })),
+    security: [{ CognitoAuthorizer: [] }],
+    paths,
+    components: {
+      securitySchemes: {
+        CognitoAuthorizer: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'Token JWT emitido por el User Pool de Cognito (header Authorization).',
+        },
+      },
+    },
+  };
+
+  return '# Archivo generado. Regenerar: cd builders && pnpm run openapi\n' + stringify(doc, { lineWidth: 0 });
+}
+
+function main(): void {
+  const checkMode = process.argv.includes('--check');
+
+  let templateText: string;
+  try {
+    templateText = readFileSync(TEMPLATE_PATH, 'utf-8');
+  } catch {
+    console.error(`[openapi] No se encontro ${TEMPLATE_PATH}.\nGenera el template SAM: cd builders && pnpm run mla`);
+    process.exit(1);
+  }
+  if (!DOMAIN_DIST) {
+    console.error('[openapi] No se encontro @skorify/domain/dist. Instala dependencias (pnpm install).');
+    process.exit(1);
+  }
+
+  indexDomain();
+  indexImpls();
+
+  const routes = parseRoutes(templateText);
+  if (routes.length === 0) {
+    console.error('[openapi] El template no contiene rutas (Path/Method). Revisa el build.');
+    process.exit(1);
+  }
+
+  const generated = buildOpenApi(routes);
+
+  if (checkMode) {
+    let current = '';
+    try { current = readFileSync(OUTPUT_PATH, 'utf-8'); } catch { current = ''; }
+    if (current !== generated) {
+      console.error('[openapi] openapi.yaml desincronizado. Regenera: cd builders && pnpm run openapi (y commitea).');
+      process.exit(1);
+    }
+    console.log(`[openapi] OK — ${routes.length} endpoints sincronizados.`);
+    return;
+  }
+
+  writeFileSync(OUTPUT_PATH, generated);
+  console.log(`[openapi] Generado openapi.yaml con ${routes.length} endpoints.`);
+}
+
+main();

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,290 +1,39 @@
-openapi: 3.0.3
-
+# Archivo generado. Regenerar: cd builders && pnpm run openapi
+openapi: 3.2.0
 info:
   title: Skorify Backend API
-  description: |
-    API RESTful para el backend de Skorify, una plataforma de predicciones deportivas y gestión de torneos.
-
-    Esta API permite gestionar:
-    - **Usuarios**: Creación y gestión de usuarios
-    - **Torneos**: Información de torneos y competiciones
-    - **Equipos**: Datos de equipos participantes
-    - **Partidos**: Creación y gestión de encuentros deportivos
-    - **Predicciones**: Sistema de pronósticos de resultados
-    - **Instancias de Torneo**: Configuración de torneos personalizados
-    - **Inscripciones de Usuario**: Registro de usuarios en instancias de torneo
-
-    ## Arquitectura
-    El backend está construido con el framework Iraca, siguiendo una arquitectura hexagonal (Clean Architecture).
-
-    ## Patrón de URLs
-    Todos los endpoints siguen el patrón: `/{feature}/{usecase-name}`
-
-    ## Sistema de Respuestas (Domain Events)
-    Todas las respuestas de la API están basadas en Domain Events. Cada endpoint retorna un objeto con:
-    - `kind`: Nombre del domain event (tipo de respuesta)
-    - `payload`: Datos de la respuesta (entidad, array, o vacío)
-    - `error`: Indica si es un error (true/false)
-
-    **Total de endpoints**: 31
-  version: 2.1.0
-
-
+  description: "API RESTful del backend de Skorify. Documento generado automaticamente desde el codigo (50 endpoints). Todas las respuestas son Domain Events: el handler responde HTTP 200 con { data, meta.code }, donde meta.code identifica el evento (exito o error de negocio)."
+  version: 1.0.0
 servers:
+  - url: https://api.skorify.cloud-manizales.com
+    description: Entorno PROD
+  - url: https://api.skorify-dev.cloud-manizales.com
+    description: Entorno DEV
   - url: http://localhost:9898
-    description: Servidor de desarrollo local (Puerto configurado en el servidor)
-  - url: https://api.skorify.com
-    description: Servidor de producción
-
+    description: Servidor local
 tags:
   - name: Match
-    description: Operaciones relacionadas con partidos deportivos (7 endpoints)
+    description: Endpoints de Match (7)
   - name: Prediction
-    description: Sistema de predicciones y pronósticos (4 endpoints)
-  - name: User
-    description: Gestión de usuarios (4 endpoints)
+    description: Endpoints de Prediction (10)
   - name: Team
-    description: Información de equipos (3 endpoints)
+    description: Endpoints de Team (5)
   - name: Tournament
-    description: Gestión de torneos (4 endpoints)
+    description: Endpoints de Tournament (5)
   - name: Tournament Instance
-    description: Instancias personalizadas de torneos (3 endpoints)
+    description: Endpoints de Tournament Instance (7)
+  - name: User
+    description: Endpoints de User (8)
   - name: User Enrollment
-    description: Inscripciones de usuarios en instancias de torneo (7 endpoints)
-
+    description: Endpoints de User Enrollment (8)
+security:
+  - CognitoAuthorizer: []
 paths:
-  # ==================== MATCH ENDPOINTS (7) ====================
-  /match/get-match-by-id:
-    get:
-      tags:
-        - Match
-      summary: Obtener partido por ID
-      description: Recupera la información detallada de un partido específico mediante su ID
-      operationId: getMatchById
-      parameters:
-        - name: matchId
-          in: query
-          required: true
-          description: ID único del partido
-          schema:
-            type: string
-            format: uuid
-          example: "match-arg-uru-copa-001"
-      responses:
-        '200':
-          description: Partido encontrado exitosamente (GottenMatchDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenMatchDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Match'
-        '404':
-          description: Partido no encontrado (MatchDoesNotExistDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [MatchDoesNotExistDomainEvent]
-
-  /match/get-matches-by-tournament-id:
-    get:
-      tags:
-        - Match
-      summary: Obtener todos los partidos de un torneo
-      description: Recupera la lista completa de partidos de un torneo específico
-      operationId: getMatchesByTournamentId
-      parameters:
-        - name: tournamentId
-          in: query
-          required: true
-          description: ID del torneo
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Partidos recuperados exitosamente (GottenMatchesDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenMatchesDomainEvent]
-                      payload:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Match'
-
-  /match/create-match:
-    put:
-      tags:
-        - Match
-      summary: Crear un nuevo partido
-      description: Registra un nuevo partido en el sistema. Valida que ambos equipos existan, que el torneo exista, y que no haya un partido duplicado en la misma etapa.
-      operationId: createMatch
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateMatchRequest'
-      responses:
-        '201':
-          description: Partido creado exitosamente (MatchSavedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [MatchSavedDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Match'
-        '400':
-          description: Error de validación (MatchTeamIsTheSameDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [MatchTeamIsTheSameDomainEvent]
-        '404':
-          description: Recurso no encontrado (NotGottenTournamentDomainEvent, MatchTeamDoesNotExistDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenTournamentDomainEvent, MatchTeamDoesNotExistDomainEvent]
-        '409':
-          description: Conflicto - El partido ya existe (MatchAlreadyExistsInSameTournamentStageDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [MatchAlreadyExistsInSameTournamentStageDomainEvent]
-        '500':
-          description: Error interno (EntityNotInstanciableDomainEvent, MatchNotSavedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [EntityNotInstanciableDomainEvent, MatchNotSavedDomainEvent]
-
-  /match/edit-match:
-    patch:
-      tags:
-        - Match
-      summary: Editar información de un partido
-      description: |
-        Actualiza los datos de un partido existente.
-
-        **Restricciones:**
-        - No se puede editar un partido en curso o finalizado
-        - No se puede cambiar el estado a "finished"
-        - No se pueden cambiar los equipos si ya hay predicciones registradas
-      operationId: editMatch
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/EditMatchRequest'
-      responses:
-        '200':
-          description: Partido actualizado exitosamente (MatchEditedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [MatchEditedDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Match'
-        '400':
-          description: Error de validación (MatchCannotBeEditedDomainEvent, MatchCannotChangeTeamsDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [MatchCannotBeEditedDomainEvent, MatchCannotChangeTeamsDomainEvent]
-        '404':
-          description: Partido no encontrado (MatchDoesNotExistDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [MatchDoesNotExistDomainEvent]
-        '500':
-          description: Error al guardar (MatchCannotBeSavedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [MatchCannotBeSavedDomainEvent]
-
   /match/calculate-match-score:
     post:
       tags:
         - Match
-      summary: Calcular puntuaciones del partido
-      description: Calcula los puntos obtenidos por los usuarios basándose en el resultado final del partido
+      summary: Calculate match score
       operationId: calculateMatchScore
       requestBody:
         required: true
@@ -292,47 +41,208 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - matchId
               properties:
                 matchId:
                   type: string
-                  format: uuid
-                  description: ID del partido para calcular puntuaciones
+                tournamentInstanceId:
+                  type: string
+              required:
+                - matchId
+                - tournamentInstanceId
       responses:
-        '200':
-          description: Puntuaciones calculadas exitosamente (GottenMatchDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: CalculatedMatchDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [GottenMatchDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Match'
-        '404':
-          description: Partido no encontrado (MatchDoesNotExistDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:CalculatedMatchDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+                  - title: MatchAlreadyCalculatedDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [MatchDoesNotExistDomainEvent]
-
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchAlreadyCalculatedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+                  - title: MatchDoesNotExistDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchDoesNotExistDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: MatchHasNotFinishedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchHasNotFinishedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /match/close-match:
     post:
       tags:
         - Match
-      summary: Cerrar un partido
-      description: Marca un partido como cerrado para apuestas y dispara eventos relacionados
+      summary: Close match
       operationId: closeMatch
       requestBody:
         required: true
@@ -340,46 +250,1012 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - matchId
               properties:
                 matchId:
                   type: string
-                  format: uuid
-                  description: ID del partido a cerrar
+                homeScore:
+                  type: number
+                awayScore:
+                  type: number
+              required:
+                - matchId
+                - homeScore
+                - awayScore
       responses:
-        '200':
-          description: Partido cerrado exitosamente (MatchClosedDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: ClosedMatchDomainEvent
+                    type: object
                     properties:
-                      kind:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:ClosedMatchDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+                  - title: MatchAlreadyClosedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchAlreadyClosedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+                  - title: MatchDoesNotExistDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchDoesNotExistDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotEditedMatchDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:NotEditedMatchDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /match/close-matches:
+    post:
+      tags:
+        - Match
+      summary: Close matches
+      operationId: closeMatches
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                matches:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      matchId:
                         type: string
-                        enum: [MatchClosedDomainEvent]
-        '404':
-          description: Partido no encontrado (MatchDoesNotExistDomainEvent)
+                      homeScore:
+                        type: number
+                      awayScore:
+                        type: number
+                    required:
+                      - matchId
+                      - homeScore
+                      - awayScore
+              required:
+                - matches
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: ClosedMatchesDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [MatchDoesNotExistDomainEvent]
-
-  # ==================== PREDICTION ENDPOINTS (4) ====================
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:ClosedMatchesDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: string
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /match/create-match:
+    put:
+      tags:
+        - Match
+      summary: Create match
+      operationId: createMatch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                homeTeamId:
+                  type: string
+                awayTeamId:
+                  type: string
+                tournamentId:
+                  type: string
+                kickOff:
+                  type: string
+                  format: date-time
+                stage:
+                  type: string
+                  enum:
+                    - group
+                    - finals
+                venue:
+                  type: string
+              required:
+                - homeTeamId
+                - awayTeamId
+                - tournamentId
+                - kickOff
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: EntityNotInstanciableDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:EntityNotInstanciableDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: MatchAlreadyExistsInSameTournamentStageDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchAlreadyExistsInSameTournamentStageDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: MatchNotSavedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchNotSavedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: MatchSavedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchSavedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+                  - title: MatchTeamDoesNotExistDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchTeamDoesNotExistDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: MatchTeamIsTheSameDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchTeamIsTheSameDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenTournamentDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:NotGottenTournamentDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /match/edit-match:
+    patch:
+      tags:
+        - Match
+      summary: Edit match
+      operationId: editMatch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                matchId:
+                  type: string
+                awayTeamId:
+                  type: string
+                homeTeamId:
+                  type: string
+                date:
+                  type: string
+                  format: date-time
+                status:
+                  type: string
+              required:
+                - matchId
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenPredictionsByMatchDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:GottenPredictionsByMatchDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            userId:
+                              type: string
+                            userEnrollmentId:
+                              type: string
+                            tournamentInstanceId:
+                              type: string
+                            matchId:
+                              type: string
+                            awayScore:
+                              type: number
+                            homeScore:
+                              type: number
+                            earnedPoints:
+                              type: number
+                            hasExactResult:
+                              type: boolean
+                            isCalculated:
+                              type: boolean
+                          required:
+                            - id
+                            - createdAt
+                            - userId
+                            - userEnrollmentId
+                            - tournamentInstanceId
+                            - matchId
+                            - awayScore
+                            - homeScore
+                            - earnedPoints
+                            - hasExactResult
+                            - isCalculated
+                    required:
+                      - meta
+                  - title: MatchCannotBeEditedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchCannotBeEditedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+                  - title: MatchCannotBeSavedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchCannotBeSavedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+                  - title: MatchCannotChangeTeamsDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchCannotChangeTeamsDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+                  - title: MatchDoesNotExistDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchDoesNotExistDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: MatchEditedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchEditedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /match/get-match-by-id:
+    get:
+      tags:
+        - Match
+      summary: Get match by id
+      operationId: getMatchById
+      parameters:
+        - name: matchId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenMatchDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:GottenMatchDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          tournamentId:
+                            type: string
+                          awayTeamId:
+                            type: string
+                          homeTeamId:
+                            type: string
+                          kickOff:
+                            type: string
+                            format: date-time
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          stage:
+                            type: string
+                            enum:
+                              - group
+                              - finals
+                          venue:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - tournamentId
+                          - awayTeamId
+                          - homeTeamId
+                          - kickOff
+                    required:
+                      - meta
+                  - title: MatchDoesNotExistDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:MatchDoesNotExistDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /match/get-matches-by-tournament-id:
+    get:
+      tags:
+        - Match
+      summary: Get matches by tournament id
+      operationId: getMatchesByTournamentId
+      parameters:
+        - name: tournamentId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenMatchesByTournamentDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Match:GottenMatchesByTournamentDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            match:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                updatedAt:
+                                  type: string
+                                  format: date-time
+                                deletedAt:
+                                  type: string
+                                  format: date-time
+                                tournamentId:
+                                  type: string
+                                awayTeamId:
+                                  type: string
+                                homeTeamId:
+                                  type: string
+                                kickOff:
+                                  type: string
+                                  format: date-time
+                                awayScore:
+                                  type: number
+                                homeScore:
+                                  type: number
+                                stage:
+                                  type: string
+                                  enum:
+                                    - group
+                                    - finals
+                                venue:
+                                  type: string
+                              required:
+                                - id
+                                - createdAt
+                                - tournamentId
+                                - awayTeamId
+                                - homeTeamId
+                                - kickOff
+                            awayTeam:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                updatedAt:
+                                  type: string
+                                  format: date-time
+                                deletedAt:
+                                  type: string
+                                  format: date-time
+                                name:
+                                  type: string
+                                tournamentId:
+                                  type: string
+                                shieldUrl:
+                                  type: string
+                              required:
+                                - id
+                                - createdAt
+                                - name
+                                - tournamentId
+                            homeTeam:
+                              type: object
+                              properties:
+                                id:
+                                  type: string
+                                createdAt:
+                                  type: string
+                                  format: date-time
+                                updatedAt:
+                                  type: string
+                                  format: date-time
+                                deletedAt:
+                                  type: string
+                                  format: date-time
+                                name:
+                                  type: string
+                                tournamentId:
+                                  type: string
+                                shieldUrl:
+                                  type: string
+                              required:
+                                - id
+                                - createdAt
+                                - name
+                                - tournamentId
+                          required:
+                            - match
+                            - awayTeam
+                            - homeTeam
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /prediction/check-match-can-bet:
     post:
       tags:
         - Prediction
-      summary: Verificar si un partido acepta apuestas
-      description: Valida si un partido específico está abierto para recibir predicciones basándose en su estado y hora de inicio
+      summary: Check match can bet
       operationId: checkMatchCanBet
       requestBody:
         required: true
@@ -387,679 +1263,2568 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - matchId
               properties:
                 matchId:
                   type: string
-                  format: uuid
-                  description: ID del partido a verificar
+              required:
+                - matchId
       responses:
-        '200':
-          description: Verificación completada exitosamente (MatchBetabilityCheckedDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: MatchBetabilityCheckedDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [MatchBetabilityCheckedDomainEvent]
-                      payload:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:MatchBetabilityCheckedDomainEvent
+                        required:
+                          - code
+                      data:
                         type: object
                         properties:
                           canBet:
                             type: boolean
-                            description: Indica si el partido acepta apuestas
-                            example: true
-              examples:
-                canBet:
-                  summary: El partido acepta apuestas
-                  value:
-                    kind: "MatchBetabilityCheckedDomainEvent"
-                    payload:
-                      canBet: true
-                    error: false
-                cannotBet:
-                  summary: El partido no acepta apuestas
-                  value:
-                    kind: "MatchBetabilityCheckedDomainEvent"
-                    payload:
-                      canBet: false
-                    error: false
-        '404':
-          description: Partido no encontrado (MatchDoesNotExistDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                        required:
+                          - canBet
+                    required:
+                      - meta
+                  - title: MatchDoesNotExistDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [MatchDoesNotExistDomainEvent]
-
-  /prediction/make-prediction:
-    post:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:MatchDoesNotExistDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /prediction/edit-prediction:
+    patch:
       tags:
         - Prediction
-      summary: Realizar una predicción
-      description: |
-        Permite a un usuario registrar su pronóstico para un partido específico.
-
-        **Validaciones:**
-        - El usuario debe existir
-        - El partido debe existir
-        - El partido debe estar abierto para apuestas
-      operationId: makePrediction
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MakePredictionRequest'
-      responses:
-        '201':
-          description: Predicción registrada exitosamente (PredictionCreatedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [PredictionCreatedDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Prediction'
-        '400':
-          description: Error de validación
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [MatchCannotBeBetedDomainEvent, UserNotActiveDomainEvent]
-              examples:
-                cannotBet:
-                  summary: El partido no acepta más apuestas
-                  value:
-                    kind: "MatchCannotBeBetedDomainEvent"
-                    payload: {}
-                    error: true
-                userNotActive:
-                  summary: El usuario no está activo
-                  value:
-                    kind: "UserNotActiveDomainEvent"
-                    payload: {}
-                    error: true
-        '404':
-          description: Usuario o partido no encontrado (NotGottenUserDomainEvent, MatchDoesNotExistDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenUserDomainEvent, MatchDoesNotExistDomainEvent]
-        '409':
-          description: El usuario ya realizó una predicción para este partido (UserAlreadyPredictedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [UserAlreadyPredictedDomainEvent]
-        '500':
-          description: Error al crear la predicción (PredictionNotCreatedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [PredictionNotCreatedDomainEvent]
-
-  /prediction/get-predictions-by-user:
-    get:
-      tags:
-        - Prediction
-      summary: Obtener predicciones de un usuario
-      description: Recupera todas las predicciones realizadas por un usuario específico en una instancia de torneo
-      operationId: getPredictionsByUser
-      parameters:
-        - name: userId
-          in: query
-          required: true
-          description: ID del usuario
-          schema:
-            type: string
-            format: uuid
-        - name: tournamentInstanceId
-          in: query
-          required: true
-          description: ID de la instancia de torneo
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Predicciones recuperadas exitosamente (GottenPredictionsByUserDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenPredictionsByUserDomainEvent]
-                      payload:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Prediction'
-
-  /prediction/get-predictions-by-match:
-    get:
-      tags:
-        - Prediction
-      summary: Obtener predicciones de un partido
-      description: Recupera todas las predicciones realizadas para un partido específico
-      operationId: getPredictionsByMatch
-      parameters:
-        - name: matchId
-          in: query
-          required: true
-          description: ID del partido
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Predicciones recuperadas exitosamente (GottenPredictionsByMatchDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenPredictionsByMatchDomainEvent]
-                      payload:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Prediction'
-
-  # ==================== USER ENDPOINTS (4) ====================
-  /user/create-user:
-    put:
-      tags:
-        - User
-      summary: Crear un nuevo usuario
-      description: Registra un nuevo usuario en el sistema. El email debe ser único.
-      operationId: createUser
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateUserRequest'
-      responses:
-        '201':
-          description: Usuario creado exitosamente (GottenUserDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenUserDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/User'
-        '409':
-          description: Ya existe un usuario con ese email (UserWithEmailAlreadyExistDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [UserWithEmailAlreadyExistDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/User'
-        '500':
-          description: Error al crear el usuario (NotGottenUserDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenUserDomainEvent]
-
-  /user/get-user-by-id:
-    get:
-      tags:
-        - User
-      summary: Obtener usuario por ID
-      description: Recupera la información de un usuario específico
-      operationId: getUserById
-      parameters:
-        - name: userId
-          in: query
-          required: true
-          description: ID del usuario
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Usuario encontrado exitosamente (GottenUserDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenUserDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/User'
-        '404':
-          description: Usuario no encontrado (NotGottenUserDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenUserDomainEvent]
-
-  /user/delete-user:
-    delete:
-      tags:
-        - User
-      summary: Eliminar un usuario
-      description: Elimina (soft delete) un usuario del sistema
-      operationId: deleteUser
-      parameters:
-        - name: userId
-          in: query
-          required: true
-          description: ID del usuario a eliminar
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Usuario eliminado exitosamente (UserFoundAndDeletedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [UserFoundAndDeletedDomainEvent]
-        '404':
-          description: Usuario no encontrado (NotGottenUserDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenUserDomainEvent]
-
-  /user/register-notification-token:
-    put:
-      tags:
-        - User
-      summary: Registrar token de notificación
-      description: Asocia un token de notificaciones push al usuario
-      operationId: registerNotificationToken
+      summary: Edit prediction
+      operationId: editPrediction
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
+              properties:
+                predictionId:
+                  type: string
+                awayScore:
+                  type: number
+                homeScore:
+                  type: number
               required:
-                - userId
-                - token
+                - predictionId
+                - awayScore
+                - homeScore
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: NotEditedPredictionDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:NotEditedPredictionDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenPredictionDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:NotGottenPredictionDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: PassedPredictionWindowDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:PassedPredictionWindowDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: PredictionEditedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:PredictionEditedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          userId:
+                            type: string
+                          userEnrollmentId:
+                            type: string
+                          tournamentInstanceId:
+                            type: string
+                          matchId:
+                            type: string
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          earnedPoints:
+                            type: number
+                          hasExactResult:
+                            type: boolean
+                          isCalculated:
+                            type: boolean
+                        required:
+                          - id
+                          - createdAt
+                          - userId
+                          - userEnrollmentId
+                          - tournamentInstanceId
+                          - matchId
+                          - awayScore
+                          - homeScore
+                          - earnedPoints
+                          - hasExactResult
+                          - isCalculated
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /prediction/edit-prediction-directly:
+    patch:
+      tags:
+        - Prediction
+      summary: Edit prediction directly
+      operationId: editPredictionDirectly
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                predictionId:
+                  type: string
+                awayScore:
+                  type: number
+                homeScore:
+                  type: number
+                earnedPoints:
+                  type: number
+                hasExactResult:
+                  type: boolean
+              required:
+                - predictionId
+                - awayScore
+                - homeScore
+                - earnedPoints
+                - hasExactResult
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: NotEditedPredictionDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:NotEditedPredictionDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenPredictionDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:NotGottenPredictionDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: PredictionEditedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:PredictionEditedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          userId:
+                            type: string
+                          userEnrollmentId:
+                            type: string
+                          tournamentInstanceId:
+                            type: string
+                          matchId:
+                            type: string
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          earnedPoints:
+                            type: number
+                          hasExactResult:
+                            type: boolean
+                          isCalculated:
+                            type: boolean
+                        required:
+                          - id
+                          - createdAt
+                          - userId
+                          - userEnrollmentId
+                          - tournamentInstanceId
+                          - matchId
+                          - awayScore
+                          - homeScore
+                          - earnedPoints
+                          - hasExactResult
+                          - isCalculated
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /prediction/get-prediction-by-id:
+    get:
+      tags:
+        - Prediction
+      summary: Get prediction by id
+      operationId: getPredictionById
+      parameters:
+        - name: predictionId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenPredictionDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:GottenPredictionDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          userId:
+                            type: string
+                          userEnrollmentId:
+                            type: string
+                          tournamentInstanceId:
+                            type: string
+                          matchId:
+                            type: string
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          earnedPoints:
+                            type: number
+                          hasExactResult:
+                            type: boolean
+                          isCalculated:
+                            type: boolean
+                        required:
+                          - id
+                          - createdAt
+                          - userId
+                          - userEnrollmentId
+                          - tournamentInstanceId
+                          - matchId
+                          - awayScore
+                          - homeScore
+                          - earnedPoints
+                          - hasExactResult
+                          - isCalculated
+                    required:
+                      - meta
+                  - title: NotGottenPredictionDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:NotGottenPredictionDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /prediction/get-prediction-rules:
+    get:
+      tags:
+        - Prediction
+      summary: Get prediction rules
+      operationId: getPredictionRules
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenPredictionRulesDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:GottenPredictionRulesDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          rules:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                name:
+                                  type: string
+                                score:
+                                  type: number
+                              required:
+                                - name
+                                - score
+                          streakBonusRules:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: number
+                                value:
+                                  type: number
+                              required:
+                                - key
+                                - value
+                        required:
+                          - rules
+                          - streakBonusRules
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /prediction/get-predictions-by-match:
+    get:
+      tags:
+        - Prediction
+      summary: Get predictions by match
+      operationId: getPredictionsByMatch
+      parameters:
+        - name: matchId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenPredictionsByMatchDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:GottenPredictionsByMatchDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            userId:
+                              type: string
+                            userEnrollmentId:
+                              type: string
+                            tournamentInstanceId:
+                              type: string
+                            matchId:
+                              type: string
+                            awayScore:
+                              type: number
+                            homeScore:
+                              type: number
+                            earnedPoints:
+                              type: number
+                            hasExactResult:
+                              type: boolean
+                            isCalculated:
+                              type: boolean
+                          required:
+                            - id
+                            - createdAt
+                            - userId
+                            - userEnrollmentId
+                            - tournamentInstanceId
+                            - matchId
+                            - awayScore
+                            - homeScore
+                            - earnedPoints
+                            - hasExactResult
+                            - isCalculated
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /prediction/get-predictions-by-match-and-tournament-instance:
+    get:
+      tags:
+        - Prediction
+      summary: Get predictions by match and tournament instance
+      operationId: getPredictionsByMatchAndTournamentInstance
+      parameters:
+        - name: matchId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: tournamentInstanceId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenPredictionsByMatchAndTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:GottenPredictionsByMatchAndTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            userId:
+                              type: string
+                            userEnrollmentId:
+                              type: string
+                            tournamentInstanceId:
+                              type: string
+                            matchId:
+                              type: string
+                            awayScore:
+                              type: number
+                            homeScore:
+                              type: number
+                            earnedPoints:
+                              type: number
+                            hasExactResult:
+                              type: boolean
+                            isCalculated:
+                              type: boolean
+                          required:
+                            - id
+                            - createdAt
+                            - userId
+                            - userEnrollmentId
+                            - tournamentInstanceId
+                            - matchId
+                            - awayScore
+                            - homeScore
+                            - earnedPoints
+                            - hasExactResult
+                            - isCalculated
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /prediction/get-predictions-by-user:
+    get:
+      tags:
+        - Prediction
+      summary: Get predictions by user
+      operationId: getPredictionsByUser
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: tournamentInstanceId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenPredictionsByUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:GottenPredictionsByUserDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            userId:
+                              type: string
+                            userEnrollmentId:
+                              type: string
+                            tournamentInstanceId:
+                              type: string
+                            matchId:
+                              type: string
+                            awayScore:
+                              type: number
+                            homeScore:
+                              type: number
+                            earnedPoints:
+                              type: number
+                            hasExactResult:
+                              type: boolean
+                            isCalculated:
+                              type: boolean
+                          required:
+                            - id
+                            - createdAt
+                            - userId
+                            - userEnrollmentId
+                            - tournamentInstanceId
+                            - matchId
+                            - awayScore
+                            - homeScore
+                            - earnedPoints
+                            - hasExactResult
+                            - isCalculated
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /prediction/make-prediction:
+    post:
+      tags:
+        - Prediction
+      summary: Make prediction
+      operationId: makePrediction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
               properties:
                 userId:
                   type: string
-                  format: uuid
-                  description: ID del usuario
-                token:
+                tournamentInstanceId:
                   type: string
-                  description: Token de notificaciones push (FCM, APNS, etc.)
+                matchId:
+                  type: string
+                awayScore:
+                  type: number
+                homeScore:
+                  type: number
+              required:
+                - userId
+                - tournamentInstanceId
+                - matchId
+                - awayScore
+                - homeScore
       responses:
-        '200':
-          description: Token registrado exitosamente (NotificationTokenAssignedDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: EntityNotInstanciableDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [NotificationTokenAssignedDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/User'
-        '400':
-          description: Error al asignar token (NotificationTokenAssignmentFailedDomainEvent)
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:EntityNotInstanciableDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: MatchCannotBeBetedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:MatchCannotBeBetedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: MatchDoesNotExistDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:MatchDoesNotExistDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: PredictionCreatedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:PredictionCreatedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          userId:
+                            type: string
+                          userEnrollmentId:
+                            type: string
+                          tournamentInstanceId:
+                            type: string
+                          matchId:
+                            type: string
+                          awayScore:
+                            type: number
+                          homeScore:
+                            type: number
+                          earnedPoints:
+                            type: number
+                          hasExactResult:
+                            type: boolean
+                          isCalculated:
+                            type: boolean
+                        required:
+                          - id
+                          - createdAt
+                          - userId
+                          - userEnrollmentId
+                          - tournamentInstanceId
+                          - matchId
+                          - awayScore
+                          - homeScore
+                          - earnedPoints
+                          - hasExactResult
+                          - isCalculated
+                    required:
+                      - meta
+                  - title: PredictionNotCreatedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:PredictionNotCreatedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserAlreadyPredictedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:UserAlreadyPredictedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserIsNotInTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:UserIsNotInTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserNotActiveDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:UserNotActiveDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /prediction/simulate-prediction:
+    post:
+      tags:
+        - Prediction
+      summary: Simulate prediction
+      operationId: simulatePrediction
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                predictionHomeScore:
+                  type: number
+                predictionAwayScore:
+                  type: number
+                matchHomeScore:
+                  type: number
+                matchAwayScore:
+                  type: number
+                streak:
+                  type: number
+              required:
+                - predictionHomeScore
+                - predictionAwayScore
+                - matchHomeScore
+                - matchAwayScore
+                - streak
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: SimulatedPredictionDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [NotificationTokenAssignmentFailedDomainEvent]
-
-  # ==================== TEAM ENDPOINTS (3) ====================
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Prediction:SimulatedPredictionDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          total:
+                            type: number
+                          breakdown:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                rule:
+                                  type: string
+                                points:
+                                  type: number
+                              required:
+                                - rule
+                                - points
+                        required:
+                          - total
+                          - breakdown
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /team/create-team:
     put:
       tags:
         - Team
-      summary: Crear un nuevo equipo
-      description: Registra un nuevo equipo en el sistema
+      summary: Create team
       operationId: createTeam
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateTeamRequest'
+              type: object
+              properties:
+                name:
+                  type: string
+                tournamentId:
+                  type: string
+              required:
+                - name
+                - tournamentId
       responses:
-        '201':
-          description: Equipo creado exitosamente (TeamSavedDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: EntityNotInstanciableDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [TeamSavedDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Team'
-        '500':
-          description: Error interno (EntityNotInstanciableDomainEvent, TeamNotSavedDomainEvent)
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:EntityNotInstanciableDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenTournamentDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:NotGottenTournamentDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TeamNotSavedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:TeamNotSavedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TeamSavedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:TeamSavedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          tournamentId:
+                            type: string
+                          shieldUrl:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - tournamentId
+                    required:
+                      - meta
+                  - title: TeamWithThatNameAlreadyExistsDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:TeamWithThatNameAlreadyExistsDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          tournamentId:
+                            type: string
+                          shieldUrl:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - tournamentId
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /team/edit-team:
+    patch:
+      tags:
+        - Team
+      summary: Edit team
+      operationId: editTeam
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                teamId:
+                  type: string
+                name:
+                  type: string
+              required:
+                - teamId
+                - name
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: NotGottenTeamDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [EntityNotInstanciableDomainEvent, TeamNotSavedDomainEvent]
-
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:NotGottenTeamDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TeamEditedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:TeamEditedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          tournamentId:
+                            type: string
+                          shieldUrl:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - tournamentId
+                    required:
+                      - meta
+                  - title: TeamNotEditedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:TeamNotEditedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /team/get-team-by-id:
     get:
       tags:
         - Team
-      summary: Obtener equipo por ID
-      description: Recupera la información de un equipo específico
+      summary: Get team by id
       operationId: getTeamById
       parameters:
         - name: teamId
           in: query
           required: true
-          description: ID del equipo
           schema:
             type: string
-            format: uuid
-          example: "team-peru"
       responses:
-        '200':
-          description: Equipo encontrado exitosamente (GottenTeamDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: GottenTeamDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [GottenTeamDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Team'
-        '404':
-          description: Equipo no encontrado (NotGottenTeamDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:GottenTeamDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          tournamentId:
+                            type: string
+                          shieldUrl:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - tournamentId
+                    required:
+                      - meta
+                  - title: NotGottenTeamDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenTeamDomainEvent]
-
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:NotGottenTeamDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /team/get-team-by-ids:
     get:
       tags:
         - Team
-      summary: Obtener múltiples equipos por IDs
-      description: Recupera la información de varios equipos simultáneamente
+      summary: Get team by ids
       operationId: getTeamByIds
       parameters:
         - name: teamIds
           in: query
           required: true
-          description: Lista de IDs de equipos separados por coma
           schema:
-            type: string
-          example: "team-peru,team-chile,team-argentina"
+            type: array
+            items:
+              type: string
       responses:
-        '200':
-          description: Equipos encontrados exitosamente (GottenTeamsDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: GottenTeamsDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [GottenTeamsDomainEvent]
-                      payload:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:GottenTeamsDomainEvent
+                        required:
+                          - code
+                      data:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Team'
-
-  # ==================== TOURNAMENT ENDPOINTS (4) ====================
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            tournamentId:
+                              type: string
+                            shieldUrl:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - tournamentId
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /team/get-teams-by-query:
+    get:
+      tags:
+        - Team
+      summary: Get teams by query
+      operationId: getTeamsByQuery
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenTeamsDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Team:GottenTeamsDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            tournamentId:
+                              type: string
+                            shieldUrl:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - tournamentId
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /tournament-instance/create-tournament-instance:
+    put:
+      tags:
+        - Tournament Instance
+      summary: Create tournament instance
+      operationId: createTournamentInstance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tournamentId:
+                  type: string
+                ownerId:
+                  type: string
+                name:
+                  type: string
+              required:
+                - tournamentId
+                - ownerId
+                - name
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: EntityNotInstanciableDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:EntityNotInstanciableDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TournamentInstanceNotSavedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:TournamentInstanceNotSavedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TournamentInstanceSavedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:TournamentInstanceSavedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          ownerId:
+                            type: string
+                          tournamentId:
+                            type: string
+                          state:
+                            type: string
+                            enum:
+                              - active
+                              - inactive
+                              - suspended
+                              - terminated
+                          inviteCode:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - ownerId
+                          - tournamentId
+                          - state
+                          - inviteCode
+                    required:
+                      - meta
+                  - title: TournamentInstanceWithSameNameDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:TournamentInstanceWithSameNameDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            ownerId:
+                              type: string
+                            tournamentId:
+                              type: string
+                            state:
+                              type: string
+                              enum:
+                                - active
+                                - inactive
+                                - suspended
+                                - terminated
+                            inviteCode:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - ownerId
+                            - tournamentId
+                            - state
+                            - inviteCode
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /tournament-instance/get-current-ranking:
+    get:
+      tags:
+        - Tournament Instance
+      summary: Get current ranking
+      operationId: getCurrentRanking
+      parameters:
+        - name: tournamentInstanceId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenTournamentInstanceCurrentRankingDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:GottenTournamentInstanceCurrentRankingDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            userId:
+                              type: string
+                            userName:
+                              type: string
+                            currentPosition:
+                              type: number
+                            lastPosition:
+                              type: number
+                            score:
+                              type: number
+                            points:
+                              type: number
+                            maxStreak:
+                              type: number
+                            streak:
+                              type: number
+                          required:
+                            - userId
+                            - userName
+                            - currentPosition
+                            - lastPosition
+                            - score
+                            - points
+                            - maxStreak
+                            - streak
+                    required:
+                      - meta
+                  - title: NotGottenTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:NotGottenTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserEnrollmentParamsNotValidDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:UserEnrollmentParamsNotValidDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /tournament-instance/get-global-tournament-instance:
+    get:
+      tags:
+        - Tournament Instance
+      summary: Get global tournament instance
+      operationId: getGlobalTournamentInstance
+      parameters:
+        - name: tournamentId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:GottenTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          ownerId:
+                            type: string
+                          tournamentId:
+                            type: string
+                          state:
+                            type: string
+                            enum:
+                              - active
+                              - inactive
+                              - suspended
+                              - terminated
+                          inviteCode:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - ownerId
+                          - tournamentId
+                          - state
+                          - inviteCode
+                    required:
+                      - meta
+                  - title: NotGottenTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:NotGottenTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /tournament-instance/get-tournament-instance-by-id:
+    get:
+      tags:
+        - Tournament Instance
+      summary: Get tournament instance by id
+      operationId: getTournamentInstanceById
+      parameters:
+        - name: tournamentInstanceId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:GottenTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          ownerId:
+                            type: string
+                          tournamentId:
+                            type: string
+                          state:
+                            type: string
+                            enum:
+                              - active
+                              - inactive
+                              - suspended
+                              - terminated
+                          inviteCode:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - ownerId
+                          - tournamentId
+                          - state
+                          - inviteCode
+                    required:
+                      - meta
+                  - title: NotGottenTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:NotGottenTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /tournament-instance/get-tournament-instance-by-invite-code:
+    get:
+      tags:
+        - Tournament Instance
+      summary: Get tournament instance by invite code
+      operationId: getTournamentInstanceByInviteCode
+      parameters:
+        - name: inviteCode
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: state
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - active
+              - inactive
+              - suspended
+              - terminated
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:GottenTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          ownerId:
+                            type: string
+                          tournamentId:
+                            type: string
+                          state:
+                            type: string
+                            enum:
+                              - active
+                              - inactive
+                              - suspended
+                              - terminated
+                          inviteCode:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - ownerId
+                          - tournamentId
+                          - state
+                          - inviteCode
+                    required:
+                      - meta
+                  - title: NotGottenTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:NotGottenTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /tournament-instance/get-tournament-instances-by-query:
+    get:
+      tags:
+        - Tournament Instance
+      summary: Get tournament instances by query
+      operationId: getTournamentInstancesByQuery
+      parameters:
+        - name: query
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenTournamentInstancesDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:GottenTournamentInstancesDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            ownerId:
+                              type: string
+                            tournamentId:
+                              type: string
+                            state:
+                              type: string
+                              enum:
+                                - active
+                                - inactive
+                                - suspended
+                                - terminated
+                            inviteCode:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - ownerId
+                            - tournamentId
+                            - state
+                            - inviteCode
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /tournament-instance/get-tournament-instances-by-tournament-id:
+    get:
+      tags:
+        - Tournament Instance
+      summary: Get tournament instances by tournament id
+      operationId: getTournamentInstancesByTournamentId
+      parameters:
+        - name: tournamentId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenTournamentInstancesDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - TournamentInstance:GottenTournamentInstancesDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            ownerId:
+                              type: string
+                            tournamentId:
+                              type: string
+                            state:
+                              type: string
+                              enum:
+                                - active
+                                - inactive
+                                - suspended
+                                - terminated
+                            inviteCode:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - ownerId
+                            - tournamentId
+                            - state
+                            - inviteCode
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /tournament/create-tournament:
     put:
       tags:
         - Tournament
-      summary: Crear un nuevo torneo
-      description: Registra un nuevo torneo en el sistema
+      summary: Create tournament
       operationId: createTournament
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateTournamentRequest'
+              type: object
+              properties:
+                name:
+                  type: string
+                matchType:
+                  type: string
+                startDate:
+                  type: string
+                  format: date-time
+                endDate:
+                  type: string
+                  format: date-time
+                userId:
+                  type: string
+              required:
+                - name
+                - matchType
+                - startDate
+                - endDate
+                - userId
       responses:
-        '201':
-          description: Torneo creado exitosamente (TournamentSavedDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: EntityNotInstanciableDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [TournamentSavedDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Tournament'
-        '500':
-          description: Error interno (EntityNotInstanciableDomainEvent, TournamentNotSavedDomainEvent)
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:EntityNotInstanciableDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TournamentInstanceWithSameNameDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:TournamentInstanceWithSameNameDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            ownerId:
+                              type: string
+                            tournamentId:
+                              type: string
+                            state:
+                              type: string
+                              enum:
+                                - active
+                                - inactive
+                                - suspended
+                                - terminated
+                            inviteCode:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - ownerId
+                            - tournamentId
+                            - state
+                            - inviteCode
+                    required:
+                      - meta
+                  - title: TournamentNotSavedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:TournamentNotSavedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TournamentSavedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:TournamentSavedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          startDate:
+                            type: string
+                            format: date-time
+                          endDate:
+                            type: string
+                            format: date-time
+                          matchType:
+                            type: string
+                          token:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - startDate
+                          - endDate
+                          - matchType
+                          - token
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /tournament/filter-tournaments:
+    get:
+      tags:
+        - Tournament
+      summary: Filter tournaments
+      operationId: filterTournaments
+      parameters:
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: FilteredTournamentsDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [EntityNotInstanciableDomainEvent, TournamentNotSavedDomainEvent]
-
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:FilteredTournamentsDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            startDate:
+                              type: string
+                              format: date-time
+                            endDate:
+                              type: string
+                              format: date-time
+                            matchType:
+                              type: string
+                            token:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - startDate
+                            - endDate
+                            - matchType
+                            - token
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /tournament/get-available-tournaments:
+    get:
+      tags:
+        - Tournament
+      summary: Get available tournaments
+      operationId: getAvailableTournaments
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: FilteredTournamentsDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:FilteredTournamentsDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            startDate:
+                              type: string
+                              format: date-time
+                            endDate:
+                              type: string
+                              format: date-time
+                            matchType:
+                              type: string
+                            token:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - startDate
+                            - endDate
+                            - matchType
+                            - token
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /tournament/get-tournament-by-id:
     get:
       tags:
         - Tournament
-      summary: Obtener torneo por ID
-      description: Recupera la información de un torneo específico
+      summary: Get tournament by id
       operationId: getTournamentById
       parameters:
         - name: tournamentId
           in: query
           required: true
-          description: ID del torneo
           schema:
             type: string
-            format: uuid
-          example: "tournament-mundial"
       responses:
-        '200':
-          description: Torneo encontrado exitosamente (GottenTournamentDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: GottenTournamentDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [GottenTournamentDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Tournament'
-        '404':
-          description: Torneo no encontrado (NotGottenTournamentDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:GottenTournamentDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          startDate:
+                            type: string
+                            format: date-time
+                          endDate:
+                            type: string
+                            format: date-time
+                          matchType:
+                            type: string
+                          token:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - startDate
+                          - endDate
+                          - matchType
+                          - token
+                    required:
+                      - meta
+                  - title: NotGottenTournamentDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenTournamentDomainEvent]
-
-  /tournament/filter-tournaments:
-    get:
-      tags:
-        - Tournament
-      summary: Filtrar torneos
-      description: Recupera torneos aplicando filtros opcionales
-      operationId: filterTournaments
-      parameters:
-        - name: name
-          in: query
-          required: false
-          description: Filtrar por nombre del torneo (búsqueda parcial)
-          schema:
-            type: string
-        - name: startDate
-          in: query
-          required: false
-          description: Filtrar por fecha de inicio
-          schema:
-            type: string
-            format: date
-        - name: endDate
-          in: query
-          required: false
-          description: Filtrar por fecha de finalización
-          schema:
-            type: string
-            format: date
-      responses:
-        '200':
-          description: Torneos recuperados exitosamente (GottenTournamentsDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenTournamentsDomainEvent]
-                      payload:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/Tournament'
-
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:NotGottenTournamentDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /tournament/update-tournament:
     patch:
       tags:
         - Tournament
-      summary: Actualizar un torneo
-      description: Actualiza la información de un torneo existente
+      summary: Update tournament
       operationId: updateTournament
       requestBody:
         required: true
@@ -1067,524 +3832,855 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - tournamentId
               properties:
                 tournamentId:
                   type: string
-                  format: uuid
-                  description: ID del torneo a actualizar
                 name:
                   type: string
-                  minLength: 3
-                  maxLength: 200
-                  description: Nuevo nombre del torneo
-                startDate:
-                  type: string
-                  format: date
-                  description: Nueva fecha de inicio
-                endDate:
-                  type: string
-                  format: date
-                  description: Nueva fecha de finalización
                 matchType:
                   type: string
-                  enum: [SingleMatchPerRound, DoubleMatchPerRound]
-                  description: Nuevo tipo de emparejamiento
+                startDate:
+                  type: string
+                  format: date-time
+                endDate:
+                  type: string
+                  format: date-time
+              required:
+                - tournamentId
+                - name
+                - matchType
+                - startDate
+                - endDate
       responses:
-        '200':
-          description: Torneo actualizado exitosamente (TournamentUpdatedDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: NotGottenTournamentDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [TournamentUpdatedDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/Tournament'
-        '400':
-          description: Fechas inválidas (TournamentInvalidDatesDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:NotGottenTournamentDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TournamentInvalidDatesDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [TournamentInvalidDatesDomainEvent]
-        '404':
-          description: Torneo no encontrado (NotGottenTournamentDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:TournamentInvalidDatesDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TournamentNotUpdatedDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenTournamentDomainEvent]
-        '500':
-          description: Error al actualizar (TournamentNotUpdatedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:TournamentNotUpdatedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: TournamentUpdatedDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [TournamentNotUpdatedDomainEvent]
-
-  # ==================== TOURNAMENT INSTANCE ENDPOINTS (3) ====================
-  /tournament-instance/create-tournament-instance:
-    put:
-      tags:
-        - Tournament Instance
-      summary: Crear una instancia de torneo
-      description: |
-        Crea una instancia personalizada de torneo con reglas y configuración específicas.
-
-        **Validaciones:**
-        - El torneo debe existir
-        - El usuario propietario debe existir
-        - El nombre de la instancia debe ser único
-      operationId: createTournamentInstance
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateTournamentInstanceRequest'
-      responses:
-        '201':
-          description: Instancia de torneo creada exitosamente (TournamentInstanceSavedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [TournamentInstanceSavedDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/TournamentInstance'
-        '404':
-          description: Recurso no encontrado (NotGottenTournamentDomainEvent, NotGottenUserDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenTournamentDomainEvent, NotGottenUserDomainEvent]
-        '409':
-          description: Ya existe una instancia con ese nombre (TournamentInstanceWithSameNameDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [TournamentInstanceWithSameNameDomainEvent]
-                      payload:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/TournamentInstance'
-        '500':
-          description: Error interno (EntityNotInstanciableDomainEvent, TournamentInstanceNotSavedDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [EntityNotInstanciableDomainEvent, TournamentInstanceNotSavedDomainEvent]
-
-  /tournament-instance/get-tournament-instance-by-id:
-    get:
-      tags:
-        - Tournament Instance
-      summary: Obtener instancia de torneo por ID
-      description: Recupera la información de una instancia de torneo específica
-      operationId: getTournamentInstanceById
-      parameters:
-        - name: instanceId
-          in: query
-          required: true
-          description: ID de la instancia de torneo
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Instancia de torneo encontrada exitosamente (GottenTournamentInstanceDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenTournamentInstanceDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/TournamentInstance'
-        '404':
-          description: Instancia de torneo no encontrada (NotGottenTournamentInstanceDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenTournamentInstanceDomainEvent]
-
-  /tournament-instance/get-tournament-instances-by-tournament-id:
-    get:
-      tags:
-        - Tournament Instance
-      summary: Obtener instancias de un torneo
-      description: Recupera todas las instancias creadas para un torneo específico
-      operationId: getTournamentInstancesByTournamentId
-      parameters:
-        - name: tournamentId
-          in: query
-          required: true
-          description: ID del torneo
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Instancias recuperadas exitosamente (GottenTournamentInstancesDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenTournamentInstancesDomainEvent]
-                      payload:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/TournamentInstance'
-
-  # ==================== USER ENROLLMENT ENDPOINTS (7) ====================
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - Tournament:TournamentUpdatedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          startDate:
+                            type: string
+                            format: date-time
+                          endDate:
+                            type: string
+                            format: date-time
+                          matchType:
+                            type: string
+                          token:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - startDate
+                          - endDate
+                          - matchType
+                          - token
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /user-enrollment/create-user-enrollment:
     put:
       tags:
         - User Enrollment
-      summary: Crear inscripción de usuario
-      description: |
-        Registra la inscripción de un usuario en una instancia de torneo.
-
-        **Validaciones:**
-        - El usuario debe existir
-        - La instancia de torneo debe existir
-        - El usuario no debe estar ya inscrito en esa instancia
+      summary: Create user enrollment
       operationId: createUserEnrollment
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateUserEnrollmentRequest'
+              type: object
+              properties:
+                userId:
+                  type: string
+                tournamentInstanceId:
+                  type: string
+              required:
+                - userId
+                - tournamentInstanceId
       responses:
-        '201':
-          description: Inscripción creada exitosamente (SavedUserEnrollmentDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: EntityNotInstanciableDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [SavedUserEnrollmentDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/UserEnrollment'
-        '400':
-          description: Parámetros inválidos (UserEnrollmentParamsNotValidDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [UserEnrollmentParamsNotValidDomainEvent]
-        '404':
-          description: Recurso no encontrado (NotGottenUserDomainEvent, NotGottenTournamentInstanceDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenUserDomainEvent, NotGottenTournamentInstanceDomainEvent]
-        '409':
-          description: El usuario ya está inscrito (UserEnrollmentAlreadyExistsDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [UserEnrollmentAlreadyExistsDomainEvent]
-                      payload:
+                      meta:
                         type: object
                         properties:
-                          userEnrollmentId:
+                          code:
                             type: string
-                            format: uuid
-        '500':
-          description: Error interno (UserEnrollmentEntityNotInstanciableDomainEvent, NotSavedUserEnrollmentDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                            enum:
+                              - UserEnrollment:EntityNotInstanciableDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenTournamentInstanceDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [UserEnrollmentEntityNotInstanciableDomainEvent, NotSavedUserEnrollmentDomainEvent]
-
-  /user-enrollment/get-user-enrollment-by-id:
-    get:
-      tags:
-        - User Enrollment
-      summary: Obtener inscripción por ID
-      description: Recupera la información de una inscripción específica
-      operationId: getUserEnrollmentById
-      parameters:
-        - name: userEnrollmentId
-          in: query
-          required: true
-          description: ID de la inscripción
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Inscripción encontrada exitosamente (GottenUserEnrollmentDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:NotGottenTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenUserDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [GottenUserEnrollmentDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/UserEnrollment'
-        '404':
-          description: Inscripción no encontrada (NotGottenUserEnrollmentDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotSavedUserEnrollmentDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenUserEnrollmentDomainEvent]
-
-  /user-enrollment/get-user-enrollments-by-user-id:
-    get:
-      tags:
-        - User Enrollment
-      summary: Obtener inscripciones de un usuario
-      description: Recupera todas las inscripciones de un usuario específico
-      operationId: getUserEnrollmentsByUserId
-      parameters:
-        - name: userId
-          in: query
-          required: true
-          description: ID del usuario
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Inscripciones recuperadas exitosamente (GottenUserEnrollmentsDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:NotSavedUserEnrollmentDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: SavedUserEnrollmentDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [GottenUserEnrollmentsDomainEvent]
-                      payload:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/UserEnrollment'
-        '404':
-          description: No se encontraron inscripciones (NotGottenUserEnrollmentsDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:SavedUserEnrollmentDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          userId:
+                            type: string
+                          tournamentInstanceId:
+                            type: string
+                          tournamentId:
+                            type: string
+                          joinedAt:
+                            type: string
+                            format: date-time
+                          lastPosition: {}
+                          currentPosition: {}
+                          currentScore:
+                            type: number
+                          streak:
+                            type: number
+                          maxStreak:
+                            type: number
+                        required:
+                          - id
+                          - createdAt
+                          - userId
+                          - tournamentInstanceId
+                          - tournamentId
+                          - joinedAt
+                          - lastPosition
+                          - currentPosition
+                          - currentScore
+                          - streak
+                          - maxStreak
+                    required:
+                      - meta
+                  - title: UserEnrollmentParamsNotValidDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenUserEnrollmentsDomainEvent]
-
-  /user-enrollment/get-user-enrollments-by-tournament-id:
-    get:
-      tags:
-        - User Enrollment
-      summary: Obtener inscripciones de un torneo
-      description: Recupera todas las inscripciones relacionadas a un torneo específico
-      operationId: getUserEnrollmentsByTournamentId
-      parameters:
-        - name: tournamentId
-          in: query
-          required: true
-          description: ID del torneo
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Inscripciones recuperadas exitosamente (GottenUserEnrollmentsDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:UserEnrollmentParamsNotValidDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserIsInTournamentInstanceDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [GottenUserEnrollmentsDomainEvent]
-                      payload:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/UserEnrollment'
-
-  /user-enrollment/get-user-enrollments-by-tournament-instance-id:
-    get:
-      tags:
-        - User Enrollment
-      summary: Obtener inscripciones de una instancia de torneo
-      description: Recupera todas las inscripciones (participantes) de una instancia de torneo específica. Útil para obtener tablas de posiciones.
-      operationId: getUserEnrollmentsByTournamentInstanceId
-      parameters:
-        - name: tournamentInstanceId
-          in: query
-          required: true
-          description: ID de la instancia de torneo
-          schema:
-            type: string
-            format: uuid
-      responses:
-        '200':
-          description: Inscripciones recuperadas exitosamente (GottenUserEnrollmentsDomainEvent)
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
-                    properties:
-                      kind:
-                        type: string
-                        enum: [GottenUserEnrollmentsDomainEvent]
-                      payload:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/UserEnrollment'
-
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:UserIsInTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          userEnrollmentId: {}
+                        required:
+                          - userEnrollmentId
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /user-enrollment/get-enrollments-without-prediction:
     get:
       tags:
         - User Enrollment
-      summary: Obtener inscripciones sin predicción
-      description: Recupera todas las inscripciones de una instancia de torneo que aún no han realizado predicción para un partido específico. Útil para enviar recordatorios.
+      summary: Get enrollments without prediction
       operationId: getEnrollmentsWithoutPrediction
       parameters:
         - name: matchId
           in: query
           required: true
-          description: ID del partido
           schema:
             type: string
-            format: uuid
         - name: tournamentInstanceId
           in: query
           required: true
-          description: ID de la instancia de torneo
           schema:
             type: string
-            format: uuid
       responses:
-        '200':
-          description: Inscripciones recuperadas exitosamente (GottenUserEnrollmentsDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: GottenUserEnrollmentsDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [GottenUserEnrollmentsDomainEvent]
-                      payload:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:GottenUserEnrollmentsDomainEvent
+                        required:
+                          - code
+                      data:
                         type: array
                         items:
-                          $ref: '#/components/schemas/UserEnrollment'
-
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            userId:
+                              type: string
+                            tournamentInstanceId:
+                              type: string
+                            tournamentId:
+                              type: string
+                            joinedAt:
+                              type: string
+                              format: date-time
+                            lastPosition: {}
+                            currentPosition: {}
+                            currentScore:
+                              type: number
+                            streak:
+                              type: number
+                            maxStreak:
+                              type: number
+                          required:
+                            - id
+                            - createdAt
+                            - userId
+                            - tournamentInstanceId
+                            - tournamentId
+                            - joinedAt
+                            - lastPosition
+                            - currentPosition
+                            - currentScore
+                            - streak
+                            - maxStreak
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user-enrollment/get-user-enrollment-by-id:
+    get:
+      tags:
+        - User Enrollment
+      summary: Get user enrollment by id
+      operationId: getUserEnrollmentById
+      parameters:
+        - name: userEnrollmentId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenUserEnrollmentDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:GottenUserEnrollmentDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          userId:
+                            type: string
+                          tournamentInstanceId:
+                            type: string
+                          tournamentId:
+                            type: string
+                          joinedAt:
+                            type: string
+                            format: date-time
+                          lastPosition: {}
+                          currentPosition: {}
+                          currentScore:
+                            type: number
+                          streak:
+                            type: number
+                          maxStreak:
+                            type: number
+                        required:
+                          - id
+                          - createdAt
+                          - userId
+                          - tournamentInstanceId
+                          - tournamentId
+                          - joinedAt
+                          - lastPosition
+                          - currentPosition
+                          - currentScore
+                          - streak
+                          - maxStreak
+                    required:
+                      - meta
+                  - title: NotGottenUserEnrollmentDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:NotGottenUserEnrollmentDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserEnrollmentParamsNotValidDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:UserEnrollmentParamsNotValidDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user-enrollment/get-user-enrollments-by-tournament-id:
+    get:
+      tags:
+        - User Enrollment
+      summary: Get user enrollments by tournament id
+      operationId: getUserEnrollmentsByTournamentId
+      parameters:
+        - name: tournamentId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenUserEnrollmentsDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:GottenUserEnrollmentsDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            userId:
+                              type: string
+                            tournamentInstanceId:
+                              type: string
+                            tournamentId:
+                              type: string
+                            joinedAt:
+                              type: string
+                              format: date-time
+                            lastPosition: {}
+                            currentPosition: {}
+                            currentScore:
+                              type: number
+                            streak:
+                              type: number
+                            maxStreak:
+                              type: number
+                          required:
+                            - id
+                            - createdAt
+                            - userId
+                            - tournamentInstanceId
+                            - tournamentId
+                            - joinedAt
+                            - lastPosition
+                            - currentPosition
+                            - currentScore
+                            - streak
+                            - maxStreak
+                    required:
+                      - meta
+                  - title: UserEnrollmentParamsNotValidDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:UserEnrollmentParamsNotValidDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user-enrollment/get-user-enrollments-by-tournament-instance-id:
+    get:
+      tags:
+        - User Enrollment
+      summary: Get user enrollments by tournament instance id
+      operationId: getUserEnrollmentsByTournamentInstanceId
+      parameters:
+        - name: tournamentInstanceId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenUserEnrollmentsDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:GottenUserEnrollmentsDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            userId:
+                              type: string
+                            tournamentInstanceId:
+                              type: string
+                            tournamentId:
+                              type: string
+                            joinedAt:
+                              type: string
+                              format: date-time
+                            lastPosition: {}
+                            currentPosition: {}
+                            currentScore:
+                              type: number
+                            streak:
+                              type: number
+                            maxStreak:
+                              type: number
+                          required:
+                            - id
+                            - createdAt
+                            - userId
+                            - tournamentInstanceId
+                            - tournamentId
+                            - joinedAt
+                            - lastPosition
+                            - currentPosition
+                            - currentScore
+                            - streak
+                            - maxStreak
+                    required:
+                      - meta
+                  - title: UserEnrollmentParamsNotValidDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:UserEnrollmentParamsNotValidDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user-enrollment/get-user-enrollments-by-user-id:
+    get:
+      tags:
+        - User Enrollment
+      summary: Get user enrollments by user id
+      operationId: getUserEnrollmentsByUserId
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenUserEnrollmentsDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:GottenUserEnrollmentsDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            userId:
+                              type: string
+                            tournamentInstanceId:
+                              type: string
+                            tournamentId:
+                              type: string
+                            joinedAt:
+                              type: string
+                              format: date-time
+                            lastPosition: {}
+                            currentPosition: {}
+                            currentScore:
+                              type: number
+                            streak:
+                              type: number
+                            maxStreak:
+                              type: number
+                          required:
+                            - id
+                            - createdAt
+                            - userId
+                            - tournamentInstanceId
+                            - tournamentId
+                            - joinedAt
+                            - lastPosition
+                            - currentPosition
+                            - currentScore
+                            - streak
+                            - maxStreak
+                    required:
+                      - meta
+                  - title: UserEnrollmentParamsNotValidDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:UserEnrollmentParamsNotValidDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user-enrollment/is-a-user-in-tournament-instance:
+    post:
+      tags:
+        - User Enrollment
+      summary: Is a user in tournament instance
+      operationId: isAUserInTournamentInstance
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+                tournamentInstanceId:
+                  type: string
+              required:
+                - userId
+                - tournamentInstanceId
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: UserIsInTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:UserIsInTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          userEnrollmentId: {}
+                        required:
+                          - userEnrollmentId
+                    required:
+                      - meta
+                  - title: UserIsNotInTournamentInstanceDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:UserIsNotInTournamentInstanceDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
   /user-enrollment/update-user-enrollment:
     patch:
       tags:
         - User Enrollment
-      summary: Actualizar inscripción de usuario
-      description: Actualiza la puntuación y estadísticas de una inscripción de usuario (usado internamente por el sistema de cálculo de puntos)
+      summary: Update user enrollment
       operationId: updateUserEnrollment
       requestBody:
         required: true
@@ -1592,650 +4688,923 @@ paths:
           application/json:
             schema:
               type: object
+              properties:
+                userEnrollmentId:
+                  type: string
+                points:
+                  type: number
+                isExact:
+                  type: boolean
               required:
                 - userEnrollmentId
                 - points
                 - isExact
-              properties:
-                userEnrollmentId:
-                  type: string
-                  format: uuid
-                  description: ID de la inscripción a actualizar
-                points:
-                  type: integer
-                  description: Puntos a asignar
-                  example: 3
-                isExact:
-                  type: boolean
-                  description: Indica si la predicción fue exacta
-                  example: true
       responses:
-        '200':
-          description: Inscripción actualizada exitosamente (SavedUserEnrollmentDomainEvent)
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: NotGottenUserEnrollmentDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [SavedUserEnrollmentDomainEvent]
-                      payload:
-                        $ref: '#/components/schemas/UserEnrollment'
-        '404':
-          description: Inscripción no encontrada (NotGottenUserEnrollmentDomainEvent)
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:NotGottenUserEnrollmentDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: SavedUserEnrollmentDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - UserEnrollment:SavedUserEnrollmentDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          userId:
+                            type: string
+                          tournamentInstanceId:
+                            type: string
+                          tournamentId:
+                            type: string
+                          joinedAt:
+                            type: string
+                            format: date-time
+                          lastPosition: {}
+                          currentPosition: {}
+                          currentScore:
+                            type: number
+                          streak:
+                            type: number
+                          maxStreak:
+                            type: number
+                        required:
+                          - id
+                          - createdAt
+                          - userId
+                          - tournamentInstanceId
+                          - tournamentId
+                          - joinedAt
+                          - lastPosition
+                          - currentPosition
+                          - currentScore
+                          - streak
+                          - maxStreak
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user/create-user:
+    put:
+      tags:
+        - User
+      summary: Create user
+      operationId: createUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                image:
+                  type: string
+              required:
+                - name
+                - email
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DomainEventResponse'
-                  - type: object
+                oneOf:
+                  - title: EntityNotInstanciableDomainEvent
+                    type: object
                     properties:
-                      kind:
-                        type: string
-                        enum: [NotGottenUserEnrollmentDomainEvent]
-
-# ==================== COMPONENTS ====================
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:EntityNotInstanciableDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: GottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:GottenUserDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          isActive:
+                            type: boolean
+                          notificationToken:
+                            type: string
+                          sub:
+                            type: string
+                          email:
+                            type: string
+                          image:
+                            type: string
+                          role:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - isActive
+                          - notificationToken
+                          - sub
+                          - email
+                          - role
+                    required:
+                      - meta
+                  - title: NotGottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserWithEmailAlreadyExistDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:UserWithEmailAlreadyExistDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          isActive:
+                            type: boolean
+                          notificationToken:
+                            type: string
+                          sub:
+                            type: string
+                          email:
+                            type: string
+                          image:
+                            type: string
+                          role:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - isActive
+                          - notificationToken
+                          - sub
+                          - email
+                          - role
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user/delete-user:
+    delete:
+      tags:
+        - User
+      summary: Delete user
+      operationId: deleteUser
+      parameters:
+        - name: Id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: NotGottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserFoundAndDeletedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:UserFoundAndDeletedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user/get-available-users:
+    get:
+      tags:
+        - User
+      summary: Get available users
+      operationId: getAvailableUsers
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenUsersDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:GottenUsersDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            isActive:
+                              type: boolean
+                            notificationToken:
+                              type: string
+                            sub:
+                              type: string
+                            email:
+                              type: string
+                            image:
+                              type: string
+                            role:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - isActive
+                            - notificationToken
+                            - sub
+                            - email
+                            - role
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user/get-user-by-id:
+    get:
+      tags:
+        - User
+      summary: Get user by id
+      operationId: getUserById
+      parameters:
+        - name: userId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:GottenUserDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          isActive:
+                            type: boolean
+                          notificationToken:
+                            type: string
+                          sub:
+                            type: string
+                          email:
+                            type: string
+                          image:
+                            type: string
+                          role:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - isActive
+                          - notificationToken
+                          - sub
+                          - email
+                          - role
+                    required:
+                      - meta
+                  - title: NotGottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user/get-user-by-sub:
+    get:
+      tags:
+        - User
+      summary: Get user by sub
+      operationId: getUserBySub
+      parameters:
+        - name: sub
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:GottenUserDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          isActive:
+                            type: boolean
+                          notificationToken:
+                            type: string
+                          sub:
+                            type: string
+                          email:
+                            type: string
+                          image:
+                            type: string
+                          role:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - isActive
+                          - notificationToken
+                          - sub
+                          - email
+                          - role
+                    required:
+                      - meta
+                  - title: NotGottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user/get-users-by-ids:
+    get:
+      tags:
+        - User
+      summary: Get users by ids
+      operationId: getUsersByIds
+      parameters:
+        - name: userIds
+          in: query
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: GottenUsersDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:GottenUsersDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+                            updatedAt:
+                              type: string
+                              format: date-time
+                            deletedAt:
+                              type: string
+                              format: date-time
+                            name:
+                              type: string
+                            isActive:
+                              type: boolean
+                            notificationToken:
+                              type: string
+                            sub:
+                              type: string
+                            email:
+                              type: string
+                            image:
+                              type: string
+                            role:
+                              type: string
+                          required:
+                            - id
+                            - createdAt
+                            - name
+                            - isActive
+                            - notificationToken
+                            - sub
+                            - email
+                            - role
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user/register-notification-token:
+    put:
+      tags:
+        - User
+      summary: Register notification token
+      operationId: registerNotificationToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+                token:
+                  type: string
+              required:
+                - userId
+                - token
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: NotGottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotificationTokenAssignedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:NotificationTokenAssignedDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          isActive:
+                            type: boolean
+                          notificationToken:
+                            type: string
+                          sub:
+                            type: string
+                          email:
+                            type: string
+                          image:
+                            type: string
+                          role:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - isActive
+                          - notificationToken
+                          - sub
+                          - email
+                          - role
+                    required:
+                      - meta
+                  - title: NotificationTokenAssignmentFailedDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:NotificationTokenAssignmentFailedDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
+  /user/register-user:
+    put:
+      tags:
+        - User
+      summary: Register user
+      operationId: registerUser
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                email:
+                  type: string
+                password:
+                  type: string
+              required:
+                - name
+                - email
+                - password
+      responses:
+        "200":
+          description: Domain Event. El tipo va en meta.code y el payload en data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - title: EntityNotInstanciableDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:EntityNotInstanciableDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: NotGottenUserDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:NotGottenUserDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserRegisteredDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:UserRegisteredDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          isActive:
+                            type: boolean
+                          notificationToken:
+                            type: string
+                          sub:
+                            type: string
+                          email:
+                            type: string
+                          image:
+                            type: string
+                          role:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - isActive
+                          - notificationToken
+                          - sub
+                          - email
+                          - role
+                    required:
+                      - meta
+                  - title: UserRegistrationInvalidParamsDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:UserRegistrationInvalidParamsDomainEvent
+                        required:
+                          - code
+                      data: {}
+                    required:
+                      - meta
+                  - title: UserWithEmailAlreadyExistDomainEvent
+                    type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            enum:
+                              - User:UserWithEmailAlreadyExistDomainEvent
+                        required:
+                          - code
+                      data:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          createdAt:
+                            type: string
+                            format: date-time
+                          updatedAt:
+                            type: string
+                            format: date-time
+                          deletedAt:
+                            type: string
+                            format: date-time
+                          name:
+                            type: string
+                          isActive:
+                            type: boolean
+                          notificationToken:
+                            type: string
+                          sub:
+                            type: string
+                          email:
+                            type: string
+                          image:
+                            type: string
+                          role:
+                            type: string
+                        required:
+                          - id
+                          - createdAt
+                          - name
+                          - isActive
+                          - notificationToken
+                          - sub
+                          - email
+                          - role
+                    required:
+                      - meta
+        "500":
+          description: Error no controlado
 components:
-  schemas:
-    # ==================== BASE DOMAIN EVENT SCHEMA ====================
-    DomainEventResponse:
-      type: object
-      description: Estructura base de respuesta de todos los endpoints. Basado en el patrón Domain Event.
-      required:
-        - kind
-        - error
-      properties:
-        kind:
-          type: string
-          description: Nombre del Domain Event que identifica el tipo de respuesta
-          example: "GottenMatchDomainEvent"
-        payload:
-          description: Datos de la respuesta (entidad, array, o objeto vacío)
-          oneOf:
-            - type: object
-            - type: array
-              items:
-                type: object
-        error:
-          type: boolean
-          description: Indica si la respuesta representa un error
-          example: false
-
-    # ==================== MATCH SCHEMAS ====================
-    Match:
-      type: object
-      description: Entidad que representa un partido deportivo
-      required:
-        - id
-        - home_team_id
-        - away_team_id
-        - tournament_id
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Identificador único del partido
-          example: "match-arg-uru-copa-001"
-        home_team_id:
-          type: string
-          format: uuid
-          description: ID del equipo local
-          example: "team-argentina"
-        away_team_id:
-          type: string
-          format: uuid
-          description: ID del equipo visitante
-          example: "team-uruguay"
-        tournament_id:
-          type: string
-          format: uuid
-          description: ID del torneo al que pertenece el partido
-          example: "tournament-mundial"
-        kick_off:
-          type: string
-          format: date-time
-          description: Fecha y hora de inicio del partido
-          example: "2026-06-18T20:00:00.000Z"
-        home_goals:
-          type: integer
-          nullable: true
-          description: Goles del equipo local
-          example: 2
-        away_goals:
-          type: integer
-          nullable: true
-          description: Goles del equipo visitante
-          example: 1
-        status:
-          type: string
-          enum: [scheduled, in_progress, finished]
-          default: scheduled
-          description: Estado actual del partido
-          example: "scheduled"
-        stage:
-          type: string
-          enum: [group, finals]
-          default: group
-          description: Etapa del torneo
-          example: "group"
-        venue:
-          type: string
-          nullable: true
-          description: Lugar donde se juega el partido
-          example: "Arena Corinthians"
-        created_at:
-          type: string
-          format: date-time
-          description: Fecha de creación del registro
-        updated_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Fecha de última actualización
-
-    CreateMatchRequest:
-      type: object
-      required:
-        - homeTeamId
-        - awayTeamId
-        - tournamentId
-        - kickOff
-        - stage
-      properties:
-        homeTeamId:
-          type: string
-          format: uuid
-          description: ID del equipo local
-          example: "team-brasil"
-        awayTeamId:
-          type: string
-          format: uuid
-          description: ID del equipo visitante
-          example: "team-colombia"
-        tournamentId:
-          type: string
-          format: uuid
-          description: ID del torneo
-          example: "tournament-mundial"
-        kickOff:
-          type: string
-          format: date-time
-          description: Fecha y hora de inicio del partido
-          example: "2026-06-18T20:00:00.000Z"
-        stage:
-          type: string
-          enum: [group, finals]
-          description: Etapa del torneo
-          example: "group"
-        venue:
-          type: string
-          description: Lugar del partido
-          example: "Arena Corinthians"
-
-    EditMatchRequest:
-      type: object
-      required:
-        - matchId
-      properties:
-        matchId:
-          type: string
-          format: uuid
-          description: ID del partido a editar
-        homeTeamId:
-          type: string
-          format: uuid
-          description: Nuevo ID del equipo local
-        awayTeamId:
-          type: string
-          format: uuid
-          description: Nuevo ID del equipo visitante
-        date:
-          type: string
-          format: date-time
-          description: Nueva fecha y hora de inicio
-        status:
-          type: string
-          enum: [scheduled, in_progress]
-          description: Nuevo estado del partido
-
-    # ==================== PREDICTION SCHEMAS ====================
-    Prediction:
-      type: object
-      description: Entidad que representa una predicción de resultado
-      required:
-        - id
-        - instance_player_id
-        - match_id
-        - pred_home_goals
-        - pred_away_goals
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Identificador único de la predicción
-        instance_player_id:
-          type: string
-          format: uuid
-          description: ID del jugador en la instancia del torneo
-        match_id:
-          type: string
-          format: uuid
-          description: ID del partido pronosticado
-        pred_home_goals:
-          type: integer
-          description: Goles pronosticados para el equipo local
-          example: 2
-        pred_away_goals:
-          type: integer
-          description: Goles pronosticados para el equipo visitante
-          example: 1
-        earned_points:
-          type: integer
-          default: 0
-          description: Puntos ganados con esta predicción
-          example: 3
-        created_at:
-          type: string
-          format: date-time
-          description: Fecha de creación de la predicción
-        updated_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Fecha de última actualización
-        deleted_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Fecha de eliminación lógica
-
-    MakePredictionRequest:
-      type: object
-      required:
-        - userId
-        - matchId
-        - predHomeGoals
-        - predAwayGoals
-      properties:
-        userId:
-          type: string
-          format: uuid
-          description: ID del usuario que realiza la predicción
-        matchId:
-          type: string
-          format: uuid
-          description: ID del partido a predecir
-        predHomeGoals:
-          type: integer
-          minimum: 0
-          description: Goles pronosticados para el equipo local
-          example: 2
-        predAwayGoals:
-          type: integer
-          minimum: 0
-          description: Goles pronosticados para el equipo visitante
-          example: 1
-
-    # ==================== USER SCHEMAS ====================
-    User:
-      type: object
-      description: Entidad que representa un usuario del sistema
-      required:
-        - id
-        - name
-        - email
-        - role
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Identificador único del usuario
-        name:
-          type: string
-          description: Nombre completo del usuario
-          example: "Juan Pérez"
-        email:
-          type: string
-          format: email
-          description: Correo electrónico único del usuario
-          example: "juan.perez@example.com"
-        notificationToken:
-          type: string
-          description: Token de notificaciones push
-        avatar_url:
-          type: string
-          format: uri
-          nullable: true
-          description: URL del avatar del usuario
-          example: "https://example.com/avatars/user123.jpg"
-        role:
-          type: string
-          enum: [general, global, instance]
-          default: general
-          description: Rol del usuario en el sistema
-          example: "general"
-        created_at:
-          type: string
-          format: date-time
-          description: Fecha de creación del usuario
-        updated_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Fecha de última actualización
-        deleted_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Fecha de eliminación lógica
-
-    CreateUserRequest:
-      type: object
-      required:
-        - name
-        - email
-      properties:
-        name:
-          type: string
-          minLength: 2
-          maxLength: 100
-          description: Nombre completo del usuario
-          example: "María García"
-        email:
-          type: string
-          format: email
-          description: Correo electrónico del usuario
-          example: "maria.garcia@example.com"
-
-    # ==================== TEAM SCHEMAS ====================
-    Team:
-      type: object
-      description: Entidad que representa un equipo deportivo
-      required:
-        - id
-        - name
-        - code
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Identificador único del equipo
-          example: "team-peru"
-        name:
-          type: string
-          description: Nombre completo del equipo
-          example: "Perú"
-        code:
-          type: string
-          description: Código único del equipo (ISO 3166-1 alpha-3 para selecciones)
-          example: "PER"
-        shield_url:
-          type: string
-          format: uri
-          nullable: true
-          description: URL del escudo del equipo
-          example: "https://example.com/shields/peru.png"
-        created_at:
-          type: string
-          format: date-time
-          description: Fecha de creación del registro
-        updated_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Fecha de última actualización
-        deleted_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Fecha de eliminación lógica
-
-    CreateTeamRequest:
-      type: object
-      required:
-        - name
-        - code
-      properties:
-        name:
-          type: string
-          minLength: 2
-          maxLength: 100
-          description: Nombre del equipo
-          example: "Brasil"
-        code:
-          type: string
-          minLength: 2
-          maxLength: 10
-          description: Código del equipo
-          example: "BRA"
-        shieldUrl:
-          type: string
-          format: uri
-          description: URL del escudo del equipo
-          example: "https://example.com/shields/brasil.png"
-
-    # ==================== TOURNAMENT SCHEMAS ====================
-    Tournament:
-      type: object
-      description: Entidad que representa un torneo o competición
-      required:
-        - id
-        - name
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Identificador único del torneo
-          example: "tournament-mundial"
-        name:
-          type: string
-          description: Nombre del torneo
-          example: "Copa Mundial FIFA 2026"
-        start_date:
-          type: string
-          format: date
-          nullable: true
-          description: Fecha de inicio del torneo
-          example: "2026-06-11"
-        end_date:
-          type: string
-          format: date
-          nullable: true
-          description: Fecha de finalización del torneo
-          example: "2026-07-19"
-        matchType:
-          type: string
-          enum: [SingleMatchPerRound, DoubleMatchPerRound]
-          description: Tipo de emparejamiento del torneo
-        token:
-          type: string
-          format: uuid
-          description: Token único del torneo
-        created_at:
-          type: string
-          format: date-time
-          description: Fecha de creación del registro
-
-    CreateTournamentRequest:
-      type: object
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          minLength: 3
-          maxLength: 200
-          description: Nombre del torneo
-          example: "Copa América 2027"
-        startDate:
-          type: string
-          format: date
-          description: Fecha de inicio
-          example: "2027-06-15"
-        endDate:
-          type: string
-          format: date
-          description: Fecha de finalización
-          example: "2027-07-15"
-        matchType:
-          type: string
-          enum: [SingleMatchPerRound, DoubleMatchPerRound]
-          description: Tipo de emparejamiento
-          example: "SingleMatchPerRound"
-
-    # ==================== TOURNAMENT INSTANCE SCHEMAS ====================
-    TournamentInstance:
-      type: object
-      description: Instancia personalizada de un torneo con reglas específicas
-      required:
-        - id
-        - tournament_id
-        - owner_user_id
-        - name
-        - state
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Identificador único de la instancia
-        tournament_id:
-          type: string
-          format: uuid
-          description: ID del torneo base
-        owner_user_id:
-          type: string
-          format: uuid
-          description: ID del usuario creador de la instancia
-        validator_user_id:
-          type: string
-          format: uuid
-          nullable: true
-          description: ID del usuario validador
-        state:
-          type: string
-          enum: [active, inactive, pending, approved, denied]
-          default: active
-          description: Estado de la instancia
-          example: "active"
-        name:
-          type: string
-          description: Nombre de la instancia
-          example: "Polla Mundial Oficina 2026"
-        price:
-          type: integer
-          default: 0
-          description: Precio de entrada a la instancia (en centavos)
-          example: 5000
-        created_at:
-          type: string
-          format: date-time
-          description: Fecha de creación
-        updated_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Fecha de última actualización
-        deleted_at:
-          type: string
-          format: date-time
-          nullable: true
-          description: Fecha de eliminación lógica
-
-    CreateTournamentInstanceRequest:
-      type: object
-      required:
-        - tournamentId
-        - ownerId
-        - name
-      properties:
-        tournamentId:
-          type: string
-          format: uuid
-          description: ID del torneo base
-        ownerId:
-          type: string
-          format: uuid
-          description: ID del usuario creador
-        name:
-          type: string
-          minLength: 3
-          maxLength: 100
-          description: Nombre de la instancia
-          example: "Polla Amigos 2026"
-        price:
-          type: integer
-          minimum: 0
-          default: 0
-          description: Precio de entrada (en centavos)
-          example: 10000
-
-    # ==================== USER ENROLLMENT SCHEMAS ====================
-    UserEnrollment:
-      type: object
-      description: |
-        Inscripción de un usuario en una instancia de torneo.
-        Representa la participación del usuario con su puntuación y posición en el ranking.
-      required:
-        - id
-        - userId
-        - tournamentInstanceId
-        - tournamentId
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Identificador único de la inscripción
-        userId:
-          type: string
-          format: uuid
-          description: ID del usuario inscrito
-        tournamentInstanceId:
-          type: string
-          format: uuid
-          description: ID de la instancia de torneo
-        tournamentId:
-          type: string
-          format: uuid
-          description: ID del torneo base
-        joinedAt:
-          type: string
-          format: date-time
-          description: Fecha y hora de inscripción
-        lastPosition:
-          type: integer
-          default: 0
-          description: Posición anterior en el ranking
-          example: 5
-        currentPosition:
-          type: integer
-          default: 0
-          description: Posición actual en el ranking
-          example: 3
-        currentScore:
-          type: integer
-          default: 0
-          description: Puntuación total acumulada
-          example: 47
-        streak:
-          type: integer
-          default: 0
-          description: Racha de aciertos consecutivos
-          example: 3
-
-    CreateUserEnrollmentRequest:
-      type: object
-      required:
-        - userId
-        - tournamentInstanceId
-      properties:
-        userId:
-          type: string
-          format: uuid
-          description: ID del usuario a inscribir
-        tournamentInstanceId:
-          type: string
-          format: uuid
-          description: ID de la instancia de torneo
+  securitySchemes:
+    CognitoAuthorizer:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: Token JWT emitido por el User Pool de Cognito (header Authorization).

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,6 @@
+extends:
+  - recommended
+rules:
+  operation-4xx-response: off
+  info-license: off
+  no-server-example.com: off


### PR DESCRIPTION
## Qué hace
Genera `openapi.yaml` automáticamente desde el código, para que la documentación nunca se desincronice de lo desplegado.

El generador (`builders/src/openapi/`) deriva:
- **Rutas** (path/método/tag) del template SAM (`builders/dist/template.yaml`).
- **Request** desde los tipos `XxxParam` del dominio (`@skorify/domain`).
- **Respuestas** desde los Domain Events que retorna cada usecase: directos y **propagados** de sub-usecases (incluye `Promise.all`, `Entity.build`, y respeta los guards `is()`/`isNot()`), con `data` tipado según el payload del evento.
- **Seguridad Cognito** global (la API va detrás del authorizer Cognito).

OpenAPI `3.2.0`, válido con Redocly.

## Scripts (en `builders/`)
- `pnpm run openapi` — regenera `openapi.yaml`
- `pnpm run openapi:check` — falla si está desincronizado
- `pnpm run openapi:lint` — valida con Redocly
- `pnpm run openapi:docs` — genera HTML estático de la doc

## CI
- Pasos `openapi:check` y `openapi:lint` en el job `sam-validate`.
- Trigger `pull_request` con `synchronize` para que los checks corran en cada push.

## Ver la doc en local
```
cd builders && pnpm run openapi:docs && xdg-open ../openapi-docs.html
```