### PR TITLE
chore: update dependencies and improve match calculation logic

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,8 +371,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+  semver@7.8.2:
+    resolution: {integrity: sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -552,7 +552,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.60.1
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.2
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -774,7 +774,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  semver@7.8.1: {}
+  semver@7.8.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/server/src/features/match/usecases/calculate-match-score.usecase-impl.ts
+++ b/server/src/features/match/usecases/calculate-match-score.usecase-impl.ts
@@ -68,6 +68,9 @@ export class CalculateMatchScoreUsecaseImpl extends CalculateMatchScoreUsecase {
 
     await this.resetStreakForMissingPredictions(matchId, tournamentInstanceId);
 
+    match.status = MatchStatus.Finished;
+    await this.matchContract.modify(match);
+
     return CalculatedMatchDomainEvent(match);
   }
 


### PR DESCRIPTION
- Bump `@skorify/data` to v1.4.5 and update related dependency versions.
- Fix match score calculation logic to filter out already calculated predictions.
- Adjust match status handling to reflect correct progression.
- Upgrade `semver` dependency to v7.8.2 for compatibility improvements.