### PR TITLE
fix(tournament): logger inyectado y validación de usuarios en el ranking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,5 @@ shared/src/storage
 **/.idea
 
 openapi-docs.html
+
+test.sh

--- a/server/src/features/tournament-instance/usecases/get-current-ranking.usecase-impl.ts
+++ b/server/src/features/tournament-instance/usecases/get-current-ranking.usecase-impl.ts
@@ -7,13 +7,12 @@ import {
   GottenTournamentInstanceDomainEvent,
   RankingItem,
 } from '@skorify/domain/tournament-instance';
-import { GetUsersByIdsUsecase, UserEntity } from '@skorify/domain/user';
+import { GetUsersByIdsUsecase, GottenUsersDomainEvent, UserEntity } from '@skorify/domain/user';
 import {
   GetUserEnrollmentsByTournamentInstanceIdUsecase,
   GottenUserEnrollmentsDomainEvent,
   UserEnrollmentEntity,
 } from '@skorify/domain/user-enrollment';
-
 import { Logger } from '@aws-lambda-powertools/logger';
 
 export class GetCurrentRankingUsecaseImpl extends GetCurrentRankingUsecase {
@@ -69,6 +68,14 @@ export class GetCurrentRankingUsecaseImpl extends GetCurrentRankingUsecase {
     const allUsersDE = await this.getUsersByIdsUsecase.call({
       userIds,
     });
+    if (allUsersDE.isNot(GottenUsersDomainEvent)) {
+      this.logger.error('No se pudieron obtener los usuarios del ranking', {
+        tournamentInstanceId,
+        userIdsCount: userIds.length,
+        event: allUsersDE.eventName,
+      });
+      return allUsersDE;
+    }
     const allUsers: UserEntity[] = allUsersDE.payload;
 
     const usersMap = new Map<string, UserEntity>(allUsers.map((u) => [u.id, u]));

--- a/server/src/features/tournament/usecases/get-available-tournaments.usecase-impl.ts
+++ b/server/src/features/tournament/usecases/get-available-tournaments.usecase-impl.ts
@@ -11,6 +11,7 @@ import {
   GottenTournamentInstanceDomainEvent,
   TournamentInstanceEntity,
 } from '@skorify/domain/tournament-instance';
+import { Logger } from '@aws-lambda-powertools/logger';
 
 type AvailableTournament = TournamentEntity & {
   globalInstanceId: string | null;
@@ -20,16 +21,17 @@ export class GetAvailableTournamentsUsecaseImpl extends GetAvailableTournamentsU
   constructor(
     private tournamentContract: TournamentContract,
     private getGlobalTournamentInstanceUsecase: GetGlobalTournamentInstanceUsecase,
+    private logger: Logger,
   ) {
     super();
   }
 
   async call(_: GetAvailableTournamentsParam): Promise<DomainEvent> {
     const tournaments = await this.tournamentContract.getAll();
-    const now = new Date();                                                                                       
-    const activeTournaments = tournaments.filter(                                                                 
-      (tournament) => tournament.startDate <= now && tournament.endDate >= now,                                   
-    ); 
+    const now = new Date();
+    const activeTournaments = tournaments.filter(
+      (tournament) => tournament.startDate <= now && tournament.endDate >= now,
+    );
 
     const availableTournaments = await Promise.all(
       activeTournaments.map(async (tournament) => {
@@ -47,7 +49,10 @@ export class GetAvailableTournamentsUsecaseImpl extends GetAvailableTournamentsU
             globalInstanceId,
           } as AvailableTournament;
         } catch (error: unknown) {
-          console.log("Error:", error);
+          this.logger.error('No se pudo obtener la instancia global del torneo', {
+            tournamentId: tournament.id,
+            error,
+          });
 
           return {
             ...tournament,


### PR DESCRIPTION
Reemplaza el console.log por el logger inyectado y valida la respuesta de getUsersByIds en el ranking para evitar el error 500.