### PR TITLE
fix(tournament): incluye torneos próximos en los disponibles

### DIFF
--- a/server/src/features/tournament/usecases/get-available-tournaments.usecase-impl.ts
+++ b/server/src/features/tournament/usecases/get-available-tournaments.usecase-impl.ts
@@ -29,9 +29,7 @@ export class GetAvailableTournamentsUsecaseImpl extends GetAvailableTournamentsU
   async call(_: GetAvailableTournamentsParam): Promise<DomainEvent> {
     const tournaments = await this.tournamentContract.getAll();
     const now = new Date();
-    const activeTournaments = tournaments.filter(
-      (tournament) => tournament.startDate <= now && tournament.endDate >= now,
-    );
+    const activeTournaments = tournaments.filter((tournament) => tournament.endDate >= now);
 
     const availableTournaments = await Promise.all(
       activeTournaments.map(async (tournament) => {


### PR DESCRIPTION
El filtro solo devolvía torneos en curso; ahora también incluye los próximos (filtra únicamente los que ya terminaron).