### PR TITLE
perf(iac): asigna memoria a las lambdas por entorno 

### DIFF
--- a/builders/src/impl/module-lambda-aws/templates/global.template.yaml
+++ b/builders/src/impl/module-lambda-aws/templates/global.template.yaml
@@ -36,9 +36,17 @@ Parameters:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Default: '/skorify/dev/data-bus-name'
 
+Mappings:
+  EnvironmentConfig:
+    dev:
+      LambdaMemorySize: 512
+    prod:
+      LambdaMemorySize: 1024
+
 Globals:
   Function:
     Runtime: nodejs22.x
+    MemorySize: !FindInMap [EnvironmentConfig, !Ref Environment, LambdaMemorySize]
     Tags:
       Project: skorify
       Environment: !Ref Environment


### PR DESCRIPTION
Todas las lambdas usaban el default de 128MB y cuatro de ellas ya tocaban el tope de memoria, con la CPU proporcional mínima. Se agrega un mapping EnvironmentConfig y MemorySize en Globals.Function para que aplique a todas las funciones según el parámetro Environment.