### PR TITLE
feat(iac): limita el throttling del API Gateway (100 rps, burst 200)

### DIFF
--- a/builders/src/impl/module-lambda-aws/templates/global.template.yaml
+++ b/builders/src/impl/module-lambda-aws/templates/global.template.yaml
@@ -277,6 +277,11 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       StageName: prod
+      MethodSettings:
+        - ResourcePath: '/*'
+          HttpMethod: '*'
+          ThrottlingRateLimit: 100
+          ThrottlingBurstLimit: 200
       Cors:
         AllowMethods: "'GET,POST,PUT,DELETE,OPTIONS,PATCH'"
         AllowHeaders: "'Content-Type,Authorization'"


### PR DESCRIPTION
## Qué cambia
Agrega `MethodSettings` al stage del API Gateway con límites de throttling: **100 rps** sostenidos y **burst de 200**, aplicados a todas las rutas (`/*`).

## Por qué
El stage no tenía ningún límite configurado. Durante la revisión de rendimiento se identificó que una ráfaga anómala de tráfico golpearía directo a las Lambdas y a la RDS (que ya llegó a 70 de ~110 conexiones máximas en dev). Con el tráfico esperado de 150–200 usuarios en pico del Mundial, 100 rps da margen amplio para el uso normal y corta ráfagas anómalas con 429 en vez de degradar la base de datos.

## Validación
- `pnpm run mla` regenera el template con el bloque `MethodSettings` correcto.
- `sam validate` pasa sobre `builders/dist/template.yaml`.
- Tras el deploy a dev, verificar en la consola de API Gateway (stage `prod` → Method Settings) los límites aplicados, y que el tráfico normal no recibe 429 (métrica `4XXError` estable).