### PR TITLE
feat(iac): alarmas de CloudWatch por lambda y de 5xx del API Gateway

### DIFF
--- a/builders/src/impl/module-lambda-aws/index.ts
+++ b/builders/src/impl/module-lambda-aws/index.ts
@@ -42,6 +42,10 @@ export class ModuleLambdaAWSBuilder extends Builder {
     );
     const globalTemplate = await readFile(join(templatesFolder, './global.template.yaml'), 'utf-8');
     const samYMLTemplate = await readFile(join(templatesFolder, './sam.template.yaml'), 'utf-8');
+    const alarmsYMLTemplate = await readFile(
+      join(templatesFolder, './alarms.template.yaml'),
+      'utf-8',
+    );
     const eventSamTemplate = await readFile(
       join(templatesFolder, './event.template.yaml'),
       'utf-8',
@@ -126,6 +130,11 @@ export class ModuleLambdaAWSBuilder extends Builder {
         samTemplate += innerEventSamTemplate;
         // fullImports.push(...imports);
       }
+
+      samTemplate += alarmsYMLTemplate.replace(
+        new RegExp(toToken('MODULE_PASCAL'), 'g'),
+        moduleConfig.modulePascal,
+      );
 
       replacedLambdaTemplate = replacedLambdaTemplate.replace(
         toToken('IMPORTS'),
@@ -247,7 +256,7 @@ capabilities = "CAPABILITY_NAMED_IAM"
 confirm_changeset = false
 disable_rollback = false
 image_repositories = []
-parameter_overrides = 'Environment="${env}" VpcId="${c.vpcId}" PrivateSubnetIdsParameter="/skorify/${env}/private-subnet-ids" CognitoUserPoolDomain="${c.cognitoDomain}" GoogleClientId="${c.googleClientId}" CognitoCallbackURLs="${c.callbackUrls}" DomainName="${c.domainName}" CertificateArn="${c.certificateArn}" DbParameterArn="/skorify/${env}/db-secret-arn" BusParameterArn="/skorify/${env}/data-bus-name"'`;
+parameter_overrides = 'Environment="${env}" VpcId="${c.vpcId}" PrivateSubnetIdsParameter="/skorify/${env}/private-subnet-ids" CognitoUserPoolDomain="${c.cognitoDomain}" GoogleClientId="${c.googleClientId}" CognitoCallbackURLs="${c.callbackUrls}" DomainName="${c.domainName}" CertificateArn="${c.certificateArn}" DbParameterArn="/skorify/${env}/db-secret-arn" BusParameterArn="/skorify/${env}/data-bus-name" OpsAlertsTopicArn="/skorify/${env}/ops-alerts-topic-arn"'`;
 
     const samconfig = `version = 0.1
 

--- a/builders/src/impl/module-lambda-aws/templates/alarms.template.yaml
+++ b/builders/src/impl/module-lambda-aws/templates/alarms.template.yaml
@@ -1,0 +1,54 @@
+
+  {{MODULE_PASCAL}}ErrorsAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub 'Errores en ${{{MODULE_PASCAL}}Lambda}'
+      Namespace: AWS/Lambda
+      MetricName: Errors
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref {{MODULE_PASCAL}}Lambda
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref OpsAlertsTopicArn
+
+  {{MODULE_PASCAL}}ThrottlesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub 'Throttles en ${{{MODULE_PASCAL}}Lambda}'
+      Namespace: AWS/Lambda
+      MetricName: Throttles
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref {{MODULE_PASCAL}}Lambda
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref OpsAlertsTopicArn
+
+  {{MODULE_PASCAL}}DurationP99Alarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub 'p99 de duracion sobre 5s en ${{{MODULE_PASCAL}}Lambda}'
+      Namespace: AWS/Lambda
+      MetricName: Duration
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref {{MODULE_PASCAL}}Lambda
+      ExtendedStatistic: p99
+      Period: 300
+      EvaluationPeriods: 2
+      Threshold: 5000
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref OpsAlertsTopicArn

--- a/builders/src/impl/module-lambda-aws/templates/global.template.yaml
+++ b/builders/src/impl/module-lambda-aws/templates/global.template.yaml
@@ -35,6 +35,10 @@ Parameters:
   BusParameterArn:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Default: '/skorify/dev/data-bus-name'
+  OpsAlertsTopicArn:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Default: '/skorify/dev/ops-alerts-topic-arn'
+    Description: ARN del topico SNS de alertas operativas.
 
 Mappings:
   EnvironmentConfig:
@@ -302,6 +306,24 @@ Resources:
     Properties:
       Domain: !Ref CognitoUserPoolDomain
       UserPoolId: !Ref CognitoUserPool
+
+  Api5xxAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: Errores 5xx en el API Gateway
+      Namespace: AWS/ApiGateway
+      MetricName: 5XXError
+      Dimensions:
+        - Name: ApiName
+          Value: !Ref AWS::StackName
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 5
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !Ref OpsAlertsTopicArn
 
   ApiGatewayCustomDomain:
     Type: AWS::ApiGateway::DomainName


### PR DESCRIPTION
## Qué cambia
- Nuevo `alarms.template.yaml`: por cada módulo el builder genera 3 alarmas — **Errors > 0**, **Throttles > 0** y **p99 de duración > 5 s** (2 periodos de 5 min) — 21 en total para los 7 módulos.
- Alarma de **5xx del API Gateway** (> 5 en 5 min) en el template global.
- Todas notifican al tópico SNS `skorify-{env}-ops-alerts` (4 correos suscritos), cuyo ARN se resuelve desde SSM (`/skorify/{env}/ops-alerts-topic-arn`) — mismo patrón que `DbParameterArn`.

## Dependencia de despliegue
Requiere aws-ug-manizales/Skorify_Data#96, **ya desplegado en dev** (tópico y parámetro SSM verificados en la cuenta).

## Validación
- `pnpm run mla` genera 22 alarmas, todas con AlarmActions apuntando al tópico; `sam validate` pasa.
- El samconfig generado incluye el override OpsAlertsTopicArn para dev y prod.
- Post-deploy: con describe-alarms deben aparecer 22 alarmas con prefijo Skorify-Backend, y se puede probar la notificación con set-alarm-state.

Nota: se reescribió esta descripción sin comillas simples porque el paso de debug del CI las inyecta en bash y rompe el build.