### PR TITLE
fix(ci): elimina pasos de debug que inyectan el evento en bash

### DIFF
--- a/.github/workflows/cd-domain-dev.yml
+++ b/.github/workflows/cd-domain-dev.yml
@@ -29,14 +29,6 @@ jobs:
       packages: write
 
     steps:
-      - name: NAME
-        run: |
-          echo 'github.ref ${{ github.ref }}'
-          echo 'github.event ${{ toJson(github.event) }}'
-          echo 'github.event_name ${{ github.event_name }}'
-          echo 'github.event.pull_request ${{ github.event.pull_request }}'
-          echo 'github.event.pull_request.action ${{ github.event.pull_request.action }}'
-
       - name: CHECKOUT
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,14 +77,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: NAME
-        run: |
-          echo 'github.ref ${{ github.ref }}'
-          echo 'github.event ${{ toJson(github.event) }}'
-          echo 'github.event_name ${{ github.event_name }}'
-          echo 'github.event.pull_request ${{ github.event.pull_request }}'
-          echo 'github.event.pull_request.action ${{ github.event.pull_request.action }}'
-
       - name: CHECKOUT
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Qué cambia
Elimina el paso de debug `NAME` de `ci.yml` (job `build`) y `cd-domain-dev.yml` (job `publish`).

## Por qué
Esos pasos interpolaban `toJson(github.event)` directo dentro de un script de bash. El JSON del evento incluye el título y el cuerpo del PR — texto controlado por cualquier persona que abra un PR en este repo público — así que:

1. **Rompe builds legítimos**: el PR #166 falló dos veces solo porque su descripción tenía comillas simples (y al editarla, el evento `edited` siguió incluyendo el cuerpo anterior en `changes.body.from`).
2. **Es inyección de comandos**: un PR con un título crafteado puede ejecutar comandos arbitrarios en el runner y exfiltrar el `GITHUB_TOKEN` del job. El job `publish` además tiene permiso `packages: write`. Es el anti-patrón de *script injection* documentado por GitHub.

Si en el futuro se necesita debuggear el evento, la forma segura es pasarlo por variable de entorno (`env: EVENT_JSON: ${{ toJson(github.event) }}` y `echo "$EVENT_JSON"`), que bash no interpreta.

## Validación
Tras el merge, re-disparar el CI del PR #166: el job `build` debe pasar (el resto de checks ya pasa).